### PR TITLE
fix🐛: Delete association when deleting menu

### DIFF
--- a/app/admin/apis/system/menu.go
+++ b/app/admin/apis/system/menu.go
@@ -3,8 +3,8 @@ package system
 import (
 	"github.com/gin-gonic/gin"
 	"github.com/gin-gonic/gin/binding"
-
 	"go-admin/app/admin/models"
+	"go-admin/common/global"
 	"go-admin/tools"
 	"go-admin/tools/app"
 )
@@ -149,6 +149,10 @@ func DeleteMenu(c *gin.Context) {
 	data.UpdateBy = tools.GetUserIdStr(c)
 	_, err = data.Delete(id)
 	tools.HasError(err, "删除失败", 500)
+
+	_, err = global.LoadPolicy()
+	tools.HasError(err, "", -1)
+
 	app.OK(c, "", "删除成功")
 }
 


### PR DESCRIPTION
如果一个角色对当前要删除的菜单的同级菜单均无权限时，删除该菜单后同时删除对上级菜单的角色菜单对应关系。
否则角色与上级菜单的对应关系会导致前端显示该角色对上级菜单下的所有菜单均有权限。
