### PR TITLE
fix:  init postgres error

### DIFF
--- a/common/database/pgsql_driver.go
+++ b/common/database/pgsql_driver.go
@@ -15,6 +15,8 @@ import (
 	"go-admin/common/global"
 	"go-admin/tools"
 	toolsConfig "go-admin/tools/config"
+
+	_ "github.com/lib/pq"
 )
 
 type PgSql struct {

--- a/common/database/pgsql_driver.go
+++ b/common/database/pgsql_driver.go
@@ -27,7 +27,7 @@ func (e *PgSql) Setup() {
 
 	global.Source = e.GetConnect()
 	log.Println(global.Source)
-	db, err := sql.Open("postgresql", global.Source)
+	db, err := sql.Open("postgres", global.Source)
 	if err != nil {
 		global.Logger.Fatal(tools.Red(e.GetDriver()+" connect error :"), err)
 	}


### PR DESCRIPTION
migrate error log in postgres
```
2021-03-04 15:10:02.492 [FATA] pgsql_driver.go:32: postgres connect error : sql: unknown driver "postgresql" (forgotten import?) 
Stack:
1.  go-admin/common/database.(*PgSql).Setup
    /Users/penzai/w/go/vgo/go-admin/common/database/pgsql_driver.go:32
2.  go-admin/common/database.Setup
    /Users/penzai/w/go/vgo/go-admin/common/database/initialize.go:18
3.  go-admin/cmd/migrate.run
    /Users/penzai/w/go/vgo/go-admin/cmd/migrate/server.go:41
4.  go-admin/cmd/migrate.glob..func1
    /Users/penzai/w/go/vgo/go-admin/cmd/migrate/server.go:23
5.  github.com/spf13/cobra.(*Command).execute
    /Users/penzai/w/go/pkg/mod/github.com/spf13/cobra@v1.0.0/command.go:846
6.  github.com/spf13/cobra.(*Command).ExecuteC
    /Users/penzai/w/go/pkg/mod/github.com/spf13/cobra@v1.0.0/command.go:950
7.  github.com/spf13/cobra.(*Command).Execute
    /Users/penzai/w/go/pkg/mod/github.com/spf13/cobra@v1.0.0/command.go:887
8.  go-admin/cmd.Execute
    /Users/penzai/w/go/vgo/go-admin/cmd/cobra.go:52
9.  main.main
    /Users/penzai/w/go/vgo/go-admin/main.go:72

```