### PR TITLE
fix:修复修改基本资料导致密码字段为空的问题

### DIFF
--- a/app/admin/service/sys_user.go
+++ b/app/admin/service/sys_user.go
@@ -123,6 +123,19 @@ func (e *SysUser) UpdateSysUserAvatar(c *request.UpdateSysUserAvatarReq, p *acti
 
 	}
 	c.Generate(&model)
+	if c.Password == "" {
+		db := e.Orm.Model(&model).Where("user_id = ?", &model.UserId).Omit("password", "salt").Updates(&model)
+		if err = db.Error; err != nil {
+			e.Log.Errorf("db error: %s", err)
+			return err
+		}
+		if db.RowsAffected == 0 {
+			err = errors.New("update userinfo error")
+			log.Warnf("db update error")
+			return err
+		}
+		return nil
+	}
 	err = e.Orm.Save(&model).Error
 	if err != nil {
 		e.Log.Errorf("Service UpdateSysUser error: %s", err)


### PR DESCRIPTION
前端修改基本资料直接e.Orm.Save()的话因为对象SysUser.Password为空,会导致写入sys_user表密码字段为空，造成无法登录。