### PR TITLE
BUGFIX:角色状态修改异常修复

### DIFF
--- a/app/admin/apis/sys_role.go
+++ b/app/admin/apis/sys_role.go
@@ -227,7 +227,7 @@ func (e SysRole) Update2Status(c *gin.Context) {
 	req := dto.UpdateStatusReq{}
 	err := e.MakeContext(c).
 		MakeOrm().
-		Bind(&req).
+		Bind(&req, binding.JSON, nil).
 		MakeService(&s.Service).
 		Errors
 	if err != nil {


### PR DESCRIPTION
切换角色状态时参数传递丢失，导致切换异常新增了一条空记录