### PR TITLE
Update 1599190683659_tables.go

### DIFF
--- a/cmd/migrate/migration/version/1599190683659_tables.go
+++ b/cmd/migrate/migration/version/1599190683659_tables.go
@@ -17,7 +17,7 @@ func init() {
 
 func _1599190683659Tables(db *gorm.DB, version string) error {
 	return db.Transaction(func(tx *gorm.DB) error {
-		err := tx.Debug().Migrator().AutoMigrate(
+		err := tx.Set("gorm:table_options", "ENGINE=InnoDB DEFAULT CHARSET=utf8").Debug().Migrator().AutoMigrate(
 			new(models.CasbinRule),
 			new(models.SysDept),
 			new(models.SysConfig),


### PR DESCRIPTION
初始化表时设置为utf8