### PR TITLE
捕获runtime.Error异常，否则接口报错不返回任何信息

### DIFF
--- a/common/middleware/customerror.go
+++ b/common/middleware/customerror.go
@@ -3,6 +3,7 @@ package middleware
 import (
 	"fmt"
 	"net/http"
+	"runtime"
 	"strconv"
 	"strings"
 	"time"
@@ -43,9 +44,14 @@ func CustomError(c *gin.Context) {
 				} else {
 					c.JSON(http.StatusOK, gin.H{
 						"code": 500,
-						"msg":  "未知异常，请联系管理员！",
+						"msg":  errStr,
 					})
 				}
+			case runtime.Error:
+				c.JSON(http.StatusOK, gin.H{
+					"code": 500,
+					"msg":  errStr.Error(),
+				})
 			default:
 				panic(err)
 			}


### PR DESCRIPTION
报错细节不应该隐藏，方便debug。500错误应该由前端统一处理，返回用户可读信息。