### PR TITLE
修复优雅重启不生效

### DIFF
--- a/cmd/api/server.go
+++ b/cmd/api/server.go
@@ -113,8 +113,6 @@ func run() error {
 			}
 		}
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
 
 	go func() {
 		// 服务连接
@@ -141,6 +139,9 @@ func run() error {
 	quit := make(chan os.Signal)
 	signal.Notify(quit, os.Interrupt)
 	<-quit
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
 	fmt.Printf("%s Shutdown Server ... \r\n", pkg.GetCurrentTimeStr())
 
 	if err := srv.Shutdown(ctx); err != nil {


### PR DESCRIPTION
- [x] 日常 bug 修复

### 💡 需求背景和解决方案

1. 要解决的具体问题。

```
context.WithTimeout(context.Background(), 5*time.Second)
```

在os.Signal之前创建了，即在接收到系统signal之前，就已经开始计时了。如果真的有请求未处理完成，会导致关闭服务时，一直就触发了context.Deadline，并没有5s的超时处理等待。修改为在os.Signal channel收到消息之后再创建context。

### 📝 更新日志

| 语言    | 更新描述                          |
| ------- | --------------------------------- |
| 🇺🇸 英文 |                                   |
| 🇨🇳 中文 | 修复平滑退出时，context超时不生效 |
