### PR TITLE
fix🐛:排序参数必须用string接收

### DIFF
--- a/template/v4/dto.go.template
+++ b/template/v4/dto.go.template
@@ -34,9 +34,9 @@ type {{.ClassName}}GetPageReq struct {
 }
 
 type {{.ClassName}}Order struct {
-    {{- $tablename := .TBName -}}
+    {{ $tablename := .TBName }}
     {{- range .Columns -}}
-    {{.GoField}} {{.GoType}} `form:"{{.JsonField}}Order"  search:"type:order;column:{{.ColumnName}};table:{{$tablename}}"`
+    {{.GoField}} string `form:"{{.JsonField}}Order"  search:"type:order;column:{{.ColumnName}};table:{{$tablename}}"`
     {{ end }}
 }
 


### PR DESCRIPTION
优化了代码生成的格式，遗留bug：最后的空行无法删除，删除之后}前面会增加空格
