### PR TITLE
fix: change 'os.Signal' channel to buffered

### DIFF
--- a/cmd/api/server.go
+++ b/cmd/api/server.go
@@ -136,7 +136,7 @@ func run() error {
 	fmt.Printf("-  Network: http://%s:%d/swagger/admin/index.html \r\n", pkg.GetLocaHonst(), config.ApplicationConfig.Port)
 	fmt.Printf("%s Enter Control + C Shutdown Server \r\n", pkg.GetCurrentTimeStr())
 	// 等待中断信号以优雅地关闭服务器（设置 5 秒的超时时间）
-	quit := make(chan os.Signal)
+	quit := make(chan os.Signal, 1)
 	signal.Notify(quit, os.Interrupt)
 	<-quit
 


### PR DESCRIPTION
## os.Signal 建议使用缓冲通道