### PR TITLE
调整postgres限定符&&修改go.mod中已经做了postgresql限定符修改的go-admin-core版本

### DIFF
--- a/app/admin/service/sys_api.go
+++ b/app/admin/service/sys_api.go
@@ -3,6 +3,7 @@ package service
 import (
 	"errors"
 	"fmt"
+	"go-admin/common/global"
 
 	"github.com/go-admin-team/go-admin-core/sdk/runtime"
 	"github.com/go-admin-team/go-admin-core/sdk/service"
@@ -34,7 +35,11 @@ func (e *SysApi) GetPage(c *dto.SysApiGetPageReq, p *actions.DataPermission, lis
 		if qType == "暂无" {
 			qType = ""
 		}
-		orm = orm.Where("`type` = ?", qType)
+		if global.Driver == "postgres" {
+			orm = orm.Where("\"type\" = ?", qType)
+		} else {
+			orm = orm.Where("`type` = ?", qType)
+		}
 	}
 	err = orm.Find(list).Limit(-1).Offset(-1).
 		Count(count).Error

--- a/go.mod
+++ b/go.mod
@@ -10,8 +10,8 @@ require (
 	github.com/bytedance/go-tagexpr/v2 v2.7.12
 	github.com/casbin/casbin/v2 v2.51.2
 	github.com/gin-gonic/gin v1.7.7
-	github.com/go-admin-team/go-admin-core v1.4.1-0.20220809101213-21187928f7d9
-	github.com/go-admin-team/go-admin-core/sdk v1.4.1-0.20220809101213-21187928f7d9
+	github.com/go-admin-team/go-admin-core v1.5.1
+	github.com/go-admin-team/go-admin-core/sdk v1.5.1
 	github.com/google/uuid v1.3.0
 	github.com/huaweicloud/huaweicloud-sdk-go-obs v3.21.12+incompatible
 	github.com/mssola/user_agent v0.5.2


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [ ] 新特性提交
- [x] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->
1.使用go-admin-ui示例代码，配置为postgresql数据库时，提示语法错误。原因为使用了mysql的限定符`，而postgresql的限定符是"
2.将postgresql相关接口修改为"限定符，与mysql的行为保持一致

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 |     Adjust postgres qualifiers and modify the go-admin-core version that has already made changes to the PostgreSQL qualifiers in go.mod    |
| 🇨🇳 中文 |      调整postgres限定符&&修改go.mod中已经做了postgresql限定符修改的go-admin-core版本    |

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
