### PR TITLE
Fix:err is never used

### DIFF
--- a/app/other/apis/sys_server_monitor.go
+++ b/app/other/apis/sys_server_monitor.go
@@ -49,9 +49,9 @@ type ServerMonitor struct {
 // GetHourDiffer 获取相差时间
 func GetHourDiffer(startTime, endTime string) int64 {
 	var hour int64
-	t1, err := time.ParseInLocation("2006-01-02 15:04:05", startTime, time.Local)
-	t2, err := time.ParseInLocation("2006-01-02 15:04:05", endTime, time.Local)
-	if err == nil && t1.Before(t2) {
+	t1, err1 := time.ParseInLocation("2006-01-02 15:04:05", startTime, time.Local)
+	t2, err2 := time.ParseInLocation("2006-01-02 15:04:05", endTime, time.Local)
+	if err1 == nil && err2 == nil && t1.Before(t2) {
 		diff := t2.Unix() - t1.Unix() //
 		hour = diff / 3600
 		return hour
@@ -70,7 +70,7 @@ func GetHourDiffer(startTime, endTime string) int64 {
 func (e ServerMonitor) ServerInfo(c *gin.Context) {
 	e.Context = c
 
-	sysInfo, err := host.Info()
+	sysInfo, _ := host.Info()
 	osDic := make(map[string]interface{}, 0)
 	osDic["goOs"] = runtime.GOOS
 	osDic["arch"] = runtime.GOARCH


### PR DESCRIPTION
Fix the problem that err is overwritten and becomes invalid

<!--
First of all, thank you for your contribution! 😄

For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.

Before submitting your pull request, please make sure the checklist below is confirmed.

Your pull requests will be merged after one of the collaborators approve.

Thank you!

-->

[[中文版模板 / Chinese template](https://github.com/go-admin-team/go-admin/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
-->

### 💡 Background and solution

coding have warnang: err is never used,Therefore, this problem was discovered and modified

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     Add a new err variable to `api.GetHourDiffer` under other to receive the returns of the two calls respectively, and ignore the err (`sysInfo, err := host.Info()`) that is not used in the original logic of `apis.ServerInfo`      |
| 🇨🇳 Chinese |    为other下的`api.GetHourDiffer`增加新的err变量，分别接收两次调用的返回,忽略掉`apis.ServerInfo`在原有逻辑中未使用的err(`sysInfo, err := host.Info()`)       |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript's definition is updated/provided or not needed
- [x] Changelog is provided or not needed
