### PR TITLE
fix🐛: 修复自动生成代码时选择字段类型为int64, 前端提交还是string 导致报错的问题

### DIFF
--- a/template/v4/vue.go.template
+++ b/template/v4/vue.go.template
@@ -175,7 +175,7 @@
                                 {{- else }}
                                     <el-form-item label="{{.ColumnComment}}" prop="{{.JsonField}}">
                                         {{ if eq "input" .HtmlType -}}
-                                            <el-input v-model="form.{{.JsonField}}" placeholder="{{.ColumnComment}}"
+                                            <el-input v-model{{if eq .GoType "int64" -}}.number{{- end}}="form.{{.JsonField}}" placeholder="{{.ColumnComment}}"
                                                       {{if eq .IsEdit "false" -}}:disabled="isEdit" {{- end}}/>
                                         {{- else if eq "select" .HtmlType -}}
                                             {{- if ne .FkTableName "" -}}


### PR DESCRIPTION

### 🤔 这个变动的性质是？

- [ ] 新特性提交
- [x] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue


### 💡 需求背景和解决方案

自动生成代码时选择字段类型为int64, 前端提交还是string 导致报错

![image](https://github.com/user-attachments/assets/bf2b83f5-2922-4aa3-926c-e366ef9cce8e)

### 📝 更新日志

在模板中判断，如果时int64类型，给 v-model 增加 v-model.number


| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 |          |
| 🇨🇳 中文 |          |

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
