### PR TITLE
fix: remove duplicate Id in GeneralDelDto.GetIds()

### DIFF
--- a/common/dto/search.go
+++ b/common/dto/search.go
@@ -13,21 +13,15 @@ type GeneralDelDto struct {
 
 func (g GeneralDelDto) GetIds() []int {
 	ids := make([]int, 0)
-	if g.Id != 0 {
+	if g.Id > 0 {
 		ids = append(ids, g.Id)
 	}
-	if len(g.Ids) > 0 {
-		for _, id := range g.Ids {
-			if id > 0 {
-				ids = append(ids, id)
-			}
-		}
-	} else {
-		if g.Id > 0 {
-			ids = append(ids, g.Id)
+	for _, id := range g.Ids {
+		if id > 0 {
+			ids = append(ids, id)
 		}
 	}
-	if len(ids) <= 0 {
+	if len(ids) == 0 {
 		//方式全部删除
 		ids = append(ids, 0)
 	}


### PR DESCRIPTION
[[中文版模板 / Chinese template](https://github.com/go-admin-team/go-admin/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

No existing issue — discovered via code review.

### 💡 Background and solution

`GeneralDelDto.GetIds()` appends `g.Id` twice when `g.Ids` is empty and `g.Id > 0`:

```go
// Before: g.Id=5, g.Ids=[] → returns [5, 5]
if g.Id != 0 {
    ids = append(ids, g.Id)  // first append
}
if len(g.Ids) > 0 {
    // skipped when Ids is empty
} else {
    if g.Id > 0 {
        ids = append(ids, g.Id)  // duplicate append
    }
}
```

Simplified to a single linear pass that collects `g.Id` (if positive), then all positive entries from `g.Ids`, preserving the existing safety guard that appends `0` when the result is empty (to prevent full-table deletes):

```go
// After: g.Id=5, g.Ids=[] → returns [5]
if g.Id > 0 {
    ids = append(ids, g.Id)
}
for _, id := range g.Ids {
    if id > 0 {
        ids = append(ids, id)
    }
}
```

### 📝 Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix duplicate Id in `GeneralDelDto.GetIds()` when `Ids` slice is empty |
| 🇨🇳 Chinese | 修复 `GeneralDelDto.GetIds()` 在 `Ids` 为空时重复添加 `Id` 的问题 |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript's definition is updated/provided or not needed
- [x] Changelog is provided or not needed