### PR TITLE
fix🐛: 限制部署步骤仅在 master 收到 push 时执行

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,12 @@ jobs:
       - name: Build
         run: env CGO_ENABLED=1 GOOS=linux GOARCH=amd64 go build -tags "sqlite3,json1" --ldflags "-extldflags -static" -o main .
 
+      # 以下推镜像与重启步骤仅在 master 收到 push 时执行。
+      # pull_request 事件同样会触发本工作流，若不加限制，任何指向 master 的
+      # PR 一经创建就会把 PR 分支的镜像推上仓库，并直接重启线上 API 服务，
+      # 且发生在合并之前。构建与编译校验不受影响，PR 仍会执行。
       - name: Build the Docker image and push
+        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
         run: |
           docker login --username=${{ secrets.DOCKER_USERNAME }} registry.ap-northeast-1.aliyuncs.com --password=${{ secrets.DOCKER_PASSWORD }}
           echo "************ docker login end"
@@ -43,6 +48,7 @@ jobs:
           echo "************ docker push end"
 
       - name: Restart server   # 第五步，重启服务
+        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
         uses: appleboy/ssh-action@0ff4204d59e8e51228ff73bce53f80d53301dee2 # v1.2.5
         env:
           GITHUB_SHA_X: ${GITHUB_SHA}

--- a/README.Zh-cn.md
+++ b/README.Zh-cn.md
@@ -19,10 +19,7 @@
 
 ## 🎬 在线体验
 
-Element UI vue体验：[https://vue2.go-admin.dev](https://vue2.go-admin.dev/#/login)
-> ⚠️⚠️⚠️ 账号 / 密码： admin / 123456
-
-Arco Design vue3 demo：[https://vue3.go-admin.dev](https://vue3.go-admin.dev/#/login)
+Element Plus vue3 体验：[https://vue.go-admin.pro](https://vue.go-admin.pro/#/login)
 > ⚠️⚠️⚠️ 账号 / 密码： admin / 123456
 
 antd体验：[https://antd.go-admin.pro](https://antd.go-admin.pro/)

--- a/README.md
+++ b/README.md
@@ -20,10 +20,7 @@ The front-end and back-end separation authority management system based on Gin +
 
 ## 🎬 Online Demo
 
-Element UI vue demo：[https://vue2.go-admin.dev](https://vue2.go-admin.dev/#/login)
-> 账号 / 密码： admin / 123456
-
-Arco Design vue3 demo：[https://vue3.go-admin.dev](https://vue3.go-admin.dev/#/login)
+Element Plus vue3 demo：[https://vue.go-admin.pro](https://vue.go-admin.pro/#/login)
 > 账号 / 密码： admin / 123456
 
 antd demo：[https://antd.go-admin.pro](https://antd.go-admin.pro/)


### PR DESCRIPTION
## 问题

`.github/workflows/build.yml` 同时由 `push` 与 `pull_request` 触发，但推送镜像与重启服务两步没有任何事件限制：

```yaml
on:
  push:
    branches: [ master ]
  pull_request:          # ← 同样会跑到下面的部署步骤
    branches: [ master ]
```

后果是**任何指向 master 的 PR 一经创建**，就会：

1. 把 PR 分支构建出的镜像推送到镜像仓库
2. `sudo docker rm -f go-admin-api` 干掉线上容器
3. 用该镜像重新启动生产 API 服务

全部发生在代码被审查和合并之前。

同仓库分支发起的 PR 可以取到 secrets（fork PR 取不到），因此这条路径实际可达。前端仓库 go-admin-ui 存在同样问题，其运行记录中 2026-08-11 有三次由 `pull_request` 事件触发的成功部署，已一并修复。

## 改动

为两个步骤加上事件判断：

```yaml
if: github.event_name == 'push' && github.ref == 'refs/heads/master'
```

额外判断 `github.ref` 是考虑到日后若有人向 `on.push.branches` 追加分支，部署不会随之扩散。

`Tidy` 与 `Build` 不受影响，PR 仍会执行编译校验 —— 只是不再碰镜像仓库和服务器。

## 附带

第二个提交更新 README 的在线体验地址：vue2 演示站已升级为 Element Plus + Vue 3 并换域名至 `vue.go-admin.pro`，Arco Design vue3 演示站已下线。

## 验证

本 PR 的检查结果即为验证 —— `pull_request` 事件使用合并提交中的 workflow 定义，因此守卫在本 PR 自身即生效，**部署步骤应显示为 skipped**。