### PR TITLE
chore🔧: 版本号升至 2.4.0

### DIFF
--- a/common/global/adm.go
+++ b/common/global/adm.go
@@ -2,7 +2,7 @@ package global
 
 const (
 	// Version go-admin version info
-	Version = "2.3.0"
+	Version = "2.4.0"
 )
 
 var (


### PR DESCRIPTION
`common/global/adm.go` 中的 `Version` 常量仍为 2.3.0，发布 v2.4.0 时遗漏。

该常量用于 `go-admin version` 命令与启动横幅，不影响功能，但会误报版本。

合并后 v2.4.0 的 tag 与 release 将重新指向包含本提交的 master。