### PR TITLE
fix: correct the commented-out queue.redis sample in settings.yml

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -61,14 +61,8 @@ settings:
 #    redis:
 #      addr: 127.0.0.1:6379
 #      password: xxxxxx
-#      producer:
-#        streamMaxLength: 100
-#        approximateMaxLength: true
-#      consumer:
-#        visibilityTimeout: 60
-#        bufferSize: 100
-#        concurrency: 10
-#        blockingTimeout: 5
-#        reclaimInterval: 1
+#      group: go-admin          # 消费组，同一应用的多个实例必须用同一个值
+#      key_prefix: go-admin     # 加在 stream key 前面，多个应用共用一个 redis 时用于隔离
+#      max_attempts: 5          # 消息投递失败的最大重试次数
   locker:
     redis:


### PR DESCRIPTION
Small follow-up to #860 (the go-admin-core upgrade that made cache/queue
actually configurable): the commented-out `queue.redis` sample in
`config/settings.yml` is stale.

## What's wrong

```yaml
#    redis:
#      addr: 127.0.0.1:6379
#      password: xxxxxx
#      producer:
#        streamMaxLength: 100
#        approximateMaxLength: true
#      consumer:
#        visibilityTimeout: 60
#        bufferSize: 100
#        concurrency: 10
#        blockingTimeout: 5
#        reclaimInterval: 1
```

`producer`/`consumer` don't exist on `config.RedisQueue` (checked against
`sdk/config/queue.go` — it only reads `addr`, `password`, and the embedded
`RedisOptions` fields, plus `group`, `key_prefix` and `max_attempts`). Filling
this in as written compiles and starts fine, since it's YAML sitting under
keys the struct never declared — every one of those settings would be
silently ignored, which is exactly the kind of thing #846 was about before
#860 fixed the bigger version of it.

## Fix

```yaml
#    redis:
#      addr: 127.0.0.1:6379
#      password: xxxxxx
#      group: go-admin          # 消费组，同一应用的多个实例必须用同一个值
#      key_prefix: go-admin     # 加在 stream key 前面，多个应用共用一个 redis 时用于隔离
#      max_attempts: 5          # 消息投递失败的最大重试次数
```

Still commented out — this only fixes what uncommenting it would actually do.
`cache.redis`'s sample (`addr`/`password`/`db`) was already correct and is
untouched.

`settings.full.yml` doesn't carry a queue/redis sample at all, so nothing to
fix there.
