### PR TITLE
fix🐛: the code generator's guards were all written backwards

### DIFF
--- a/app/other/apis/tools/db_columns.go
+++ b/app/other/apis/tools/db_columns.go
@@ -41,7 +41,7 @@ func (e Gen) GetDBColumnList(c *gin.Context) {
 	}
 
 	data.TableName = c.Request.FormValue("tableName")
-	pkg.Assert(data.TableName == "", "table name cannot be empty！", 500)
+	pkg.Assert(data.TableName != "", "table name cannot be empty！", 500)
 	result, count, err := data.GetPage(db, pageSize, pageIndex)
 	if err != nil {
 		log.Errorf("GetPage error, %s", err.Error())

--- a/app/other/apis/tools/db_columns_test.go
+++ b/app/other/apis/tools/db_columns_test.go
@@ -1,0 +1,78 @@
+package tools
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/glebarez/sqlite"
+	"github.com/go-admin-team/go-admin-core/logger"
+	"github.com/go-admin-team/go-admin-core/sdk/config"
+	"github.com/go-admin-team/go-admin-core/sdk/pkg"
+	"gorm.io/gorm"
+
+	"go-admin/common/middleware"
+)
+
+const emptyTableNameMsg = "table name cannot be empty！"
+
+// bodyOf covers both the success and the CustomError shape: both carry msg.
+type bodyOf struct {
+	Code int    `json:"code"`
+	Msg  string `json:"msg"`
+}
+
+// newColumnListEngine wires the handler the way the router does, including the
+// middleware that turns pkg.Assert's panic into a response.
+func newColumnListEngine(t *testing.T) *gin.Engine {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+
+	db, err := gorm.Open(sqlite.Open("file::memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+
+	// The query targets MySQL's information_schema; the driver setting only has
+	// to select that branch, the statement itself is never expected to succeed.
+	previous := config.DatabaseConfig.Driver
+	config.DatabaseConfig.Driver = "mysql"
+	t.Cleanup(func() { config.DatabaseConfig.Driver = previous })
+
+	r := gin.New()
+	r.Use(middleware.CustomError)
+	r.GET("/db/columns/page", func(c *gin.Context) {
+		c.Set("db", db)
+		c.Set(pkg.LoggerKey, logger.NewHelper(logger.DefaultLogger))
+		Gen{}.GetDBColumnList(c)
+	})
+	return r
+}
+
+func columnListMsg(t *testing.T, r *gin.Engine, query string) bodyOf {
+	t.Helper()
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/db/columns/page"+query, nil))
+
+	var body bodyOf
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode %q: %v", w.Body.String(), err)
+	}
+	return body
+}
+
+func TestGetDBColumnList_AcceptsATableName(t *testing.T) {
+	body := columnListMsg(t, newColumnListEngine(t), "?tableName=sys_user")
+	if body.Msg == emptyTableNameMsg {
+		t.Fatalf("request carried a table name and was still rejected as empty: %+v", body)
+	}
+}
+
+func TestGetDBColumnList_RejectsAMissingTableName(t *testing.T) {
+	body := columnListMsg(t, newColumnListEngine(t), "")
+	if body.Msg != emptyTableNameMsg {
+		t.Fatalf("missing table name should be rejected, got %+v", body)
+	}
+}

--- a/app/other/models/tools/db_columns.go
+++ b/app/other/models/tools/db_columns.go
@@ -28,14 +28,13 @@ func (e *DBColumns) GetPage(tx *gorm.DB, pageSize int, pageIndex int) ([]DBColum
 	var count int64
 	table := new(gorm.DB)
 
+	if e.TableName == "" {
+		return nil, 0, errors.New("table name cannot be empty！")
+	}
+
 	if config.DatabaseConfig.Driver == "mysql" {
 		table = tx.Table("information_schema.`COLUMNS`")
 		table = table.Where("table_schema= ? ", config.GenConfig.DBName)
-
-		if e.TableName != "" {
-			return nil, 0, errors.New("table name cannot be empty！")
-		}
-
 		table = table.Where("TABLE_NAME = ?", e.TableName)
 	}
 

--- a/app/other/models/tools/db_columns.go
+++ b/app/other/models/tools/db_columns.go
@@ -24,44 +24,36 @@ type DBColumns struct {
 }
 
 func (e *DBColumns) GetPage(tx *gorm.DB, pageSize int, pageIndex int) ([]DBColumns, int, error) {
+	pkg.Assert(config.DatabaseConfig.Driver == "mysql", "目前只支持mysql数据库", 500)
+
 	var doc []DBColumns
 	var count int64
-	table := new(gorm.DB)
 
 	if e.TableName == "" {
 		return nil, 0, errors.New("table name cannot be empty！")
 	}
 
-	if config.DatabaseConfig.Driver == "mysql" {
-		table = tx.Table("information_schema.`COLUMNS`")
-		table = table.Where("table_schema= ? ", config.GenConfig.DBName)
-		table = table.Where("TABLE_NAME = ?", e.TableName)
-	}
+	table := tx.Table("information_schema.`COLUMNS`")
+	table = table.Where("table_schema= ? ", config.GenConfig.DBName)
+	table = table.Where("TABLE_NAME = ?", e.TableName)
 
 	if err := table.Offset((pageIndex - 1) * pageSize).Limit(pageSize).Find(&doc).Offset(-1).Limit(-1).Count(&count).Error; err != nil {
 		return nil, 0, err
 	}
-	//table.Count(&count)
 	return doc, int(count), nil
-
 }
 
 func (e *DBColumns) GetList(tx *gorm.DB) ([]DBColumns, error) {
-	var doc []DBColumns
-	table := new(gorm.DB)
+	pkg.Assert(config.DatabaseConfig.Driver == "mysql", "目前只支持mysql数据库", 500)
 
+	var doc []DBColumns
 	if e.TableName == "" {
 		return nil, errors.New("table name cannot be empty！")
 	}
 
-	if config.DatabaseConfig.Driver == "mysql" {
-		table = tx.Table("information_schema.columns")
-		table = table.Where("table_schema= ? ", config.GenConfig.DBName)
-
-		table = table.Where("TABLE_NAME = ?", e.TableName).Order("ORDINAL_POSITION asc")
-	} else {
-		pkg.Assert(true, "目前只支持mysql数据库", 500)
-	}
+	table := tx.Table("information_schema.columns")
+	table = table.Where("table_schema= ? ", config.GenConfig.DBName)
+	table = table.Where("TABLE_NAME = ?", e.TableName).Order("ORDINAL_POSITION asc")
 	if err := table.Find(&doc).Error; err != nil {
 		return doc, err
 	}

--- a/app/other/models/tools/db_tables.go
+++ b/app/other/models/tools/db_tables.go
@@ -25,9 +25,22 @@ func (e *DBTables) GetPage(tx *gorm.DB, pageSize int, pageIndex int) ([]DBTables
 	var doc []DBTables
 	var count int64
 
+	// Tables already registered with the generator are not candidates. Read them
+	// through the model on this connection: the subquery used to spell the
+	// schema out by hand, so it only resolved when sys_tables happened to live
+	// in the schema being generated from, and it counted soft-deleted rows.
+	var generated []string
+	if err := tx.Model(&SysTables{}).Pluck("table_name", &generated).Error; err != nil {
+		return nil, 0, err
+	}
+
 	table := tx.Table("information_schema.tables")
-	table = table.Where("TABLE_NAME not in (select table_name from `" + config2.GenConfig.DBName + "`.sys_tables) ")
 	table = table.Where("table_schema= ? ", config2.GenConfig.DBName)
+	if len(generated) > 0 {
+		// NOT IN (NULL) is unknown for every row, so an empty list has to skip
+		// the clause instead of rendering it.
+		table = table.Where("TABLE_NAME not in (?)", generated)
+	}
 
 	if e.TableName != "" {
 		table = table.Where("TABLE_NAME = ?", e.TableName)

--- a/app/other/models/tools/db_tables.go
+++ b/app/other/models/tools/db_tables.go
@@ -20,43 +20,36 @@ type DBTables struct {
 }
 
 func (e *DBTables) GetPage(tx *gorm.DB, pageSize int, pageIndex int) ([]DBTables, int, error) {
+	pkg.Assert(config2.DatabaseConfig.Driver == "mysql", "目前只支持mysql数据库", 500)
+
 	var doc []DBTables
-	table := new(gorm.DB)
 	var count int64
 
-	if config2.DatabaseConfig.Driver == "mysql" {
-		table = tx.Table("information_schema.tables")
-		table = table.Where("TABLE_NAME not in (select table_name from `" + config2.GenConfig.DBName + "`.sys_tables) ")
-		table = table.Where("table_schema= ? ", config2.GenConfig.DBName)
+	table := tx.Table("information_schema.tables")
+	table = table.Where("TABLE_NAME not in (select table_name from `" + config2.GenConfig.DBName + "`.sys_tables) ")
+	table = table.Where("table_schema= ? ", config2.GenConfig.DBName)
 
-		if e.TableName != "" {
-			table = table.Where("TABLE_NAME = ?", e.TableName)
-		}
-		if err := table.Offset((pageIndex - 1) * pageSize).Limit(pageSize).Find(&doc).Offset(-1).Limit(-1).Count(&count).Error; err != nil {
-			return nil, 0, err
-		}
-	} else {
-		pkg.Assert(true, "目前只支持mysql数据库", 500)
+	if e.TableName != "" {
+		table = table.Where("TABLE_NAME = ?", e.TableName)
 	}
-
-	//table.Count(&count)
+	if err := table.Offset((pageIndex - 1) * pageSize).Limit(pageSize).Find(&doc).Offset(-1).Limit(-1).Count(&count).Error; err != nil {
+		return nil, 0, err
+	}
 	return doc, int(count), nil
 }
 
 func (e *DBTables) Get(tx *gorm.DB) (DBTables, error) {
+	pkg.Assert(config2.DatabaseConfig.Driver == "mysql", "目前只支持mysql数据库", 500)
+
 	var doc DBTables
-	if config2.DatabaseConfig.Driver == "mysql" {
-		table := tx.Table("information_schema.tables")
-		table = table.Where("table_schema= ? ", config2.GenConfig.DBName)
-		if e.TableName == "" {
-			return doc, errors.New("table name cannot be empty！")
-		}
-		table = table.Where("TABLE_NAME = ?", e.TableName)
-		if err := table.First(&doc).Error; err != nil {
-			return doc, err
-		}
-	} else {
-		pkg.Assert(true, "目前只支持mysql数据库", 500)
+	if e.TableName == "" {
+		return doc, errors.New("table name cannot be empty！")
+	}
+	table := tx.Table("information_schema.tables")
+	table = table.Where("table_schema= ? ", config2.GenConfig.DBName)
+	table = table.Where("TABLE_NAME = ?", e.TableName)
+	if err := table.First(&doc).Error; err != nil {
+		return doc, err
 	}
 	return doc, nil
 }

--- a/app/other/models/tools/db_tables_test.go
+++ b/app/other/models/tools/db_tables_test.go
@@ -1,0 +1,116 @@
+package tools
+
+import (
+	"testing"
+
+	"github.com/glebarez/sqlite"
+	config2 "github.com/go-admin-team/go-admin-core/sdk/config"
+	"gorm.io/gorm"
+)
+
+const generatorSchema = "go_admin_test"
+
+// newCandidateDB stands in for MySQL: sqlite is given an attached database
+// called information_schema so the same query runs, and sys_tables lives on the
+// connection the way it does in production.
+func newCandidateDB(t *testing.T, tables ...string) *gorm.DB {
+	t.Helper()
+
+	db, err := gorm.Open(sqlite.Open("file::memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	if err := db.Exec(`ATTACH DATABASE ':memory:' AS information_schema`).Error; err != nil {
+		t.Fatalf("attach information_schema: %v", err)
+	}
+	if err := db.Exec("CREATE TABLE information_schema.`tables` (" +
+		"TABLE_NAME text, TABLE_SCHEMA text, `ENGINE` text, TABLE_ROWS text," +
+		"TABLE_COLLATION text, CREATE_TIME text, UPDATE_TIME text, TABLE_COMMENT text)").Error; err != nil {
+		t.Fatalf("create information_schema.tables: %v", err)
+	}
+	for _, name := range tables {
+		if err := db.Exec("INSERT INTO information_schema.`tables` (TABLE_NAME, TABLE_SCHEMA) VALUES (?, ?)",
+			name, generatorSchema).Error; err != nil {
+			t.Fatalf("insert %s: %v", name, err)
+		}
+	}
+	if err := db.AutoMigrate(new(SysTables)); err != nil {
+		t.Fatalf("migrate sys_tables: %v", err)
+	}
+
+	previousDriver := config2.DatabaseConfig.Driver
+	previousName := config2.GenConfig.DBName
+	config2.DatabaseConfig.Driver = "mysql"
+	config2.GenConfig.DBName = generatorSchema
+	t.Cleanup(func() {
+		config2.DatabaseConfig.Driver = previousDriver
+		config2.GenConfig.DBName = previousName
+	})
+	return db
+}
+
+func candidateNames(t *testing.T, db *gorm.DB) []string {
+	t.Helper()
+	found, _, err := new(DBTables).GetPage(db, 100, 1)
+	if err != nil {
+		t.Fatalf("GetPage: %v", err)
+	}
+	names := make([]string, 0, len(found))
+	for _, row := range found {
+		names = append(names, row.TableName)
+	}
+	return names
+}
+
+func contains(names []string, want string) bool {
+	for _, name := range names {
+		if name == want {
+			return true
+		}
+	}
+	return false
+}
+
+// An empty sys_tables must not filter everything out - that is what a bare
+// NOT IN (empty set) does, and a fresh install is exactly the case where the
+// list matters most.
+func TestGetPageListsEveryTableWhenNoneAreRegistered(t *testing.T) {
+	db := newCandidateDB(t, "sys_user", "sys_role")
+
+	names := candidateNames(t, db)
+	if len(names) != 2 {
+		t.Fatalf("want both tables offered on a fresh install, got %v", names)
+	}
+}
+
+func TestGetPageSkipsAlreadyRegisteredTables(t *testing.T) {
+	db := newCandidateDB(t, "sys_user", "sys_role")
+	if err := db.Create(&SysTables{TBName: "sys_user"}).Error; err != nil {
+		t.Fatalf("register sys_user: %v", err)
+	}
+
+	names := candidateNames(t, db)
+	if contains(names, "sys_user") {
+		t.Errorf("sys_user is already registered and was offered again: %v", names)
+	}
+	if !contains(names, "sys_role") {
+		t.Errorf("sys_role is not registered and was withheld: %v", names)
+	}
+}
+
+// Deleting the generator entry has to hand the table back, which the raw
+// subquery never did: it read the row whether or not it was soft-deleted.
+func TestGetPageOffersTablesWhoseEntryWasDeleted(t *testing.T) {
+	db := newCandidateDB(t, "sys_user")
+	registered := SysTables{TBName: "sys_user"}
+	if err := db.Create(&registered).Error; err != nil {
+		t.Fatalf("register sys_user: %v", err)
+	}
+	if err := db.Delete(&registered).Error; err != nil {
+		t.Fatalf("delete the entry: %v", err)
+	}
+
+	if names := candidateNames(t, db); !contains(names, "sys_user") {
+		t.Errorf("the generator entry is deleted, sys_user should be a candidate again: %v", names)
+	}
+}

--- a/app/other/models/tools/driver_guard_test.go
+++ b/app/other/models/tools/driver_guard_test.go
@@ -1,0 +1,52 @@
+package tools
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/go-admin-team/go-admin-core/sdk/config"
+	"gorm.io/gorm"
+)
+
+// The generator reads MySQL's information_schema and nothing else. Every entry
+// point says so, but the guard used to be written pkg.Assert(true, ...), which
+// never fires: pkg.Assert panics when its condition is false. A non-mysql
+// deployment therefore fell through to a query built on a zero-value *gorm.DB.
+//
+// tx is nil on purpose - the assertion has to come before anything touches it.
+func TestCodegenModelsRefuseNonMySQLDrivers(t *testing.T) {
+	previous := config.DatabaseConfig.Driver
+	config.DatabaseConfig.Driver = "postgres"
+	t.Cleanup(func() { config.DatabaseConfig.Driver = previous })
+
+	cases := map[string]func(*gorm.DB){
+		"DBTables.GetPage": func(tx *gorm.DB) {
+			_, _, _ = new(DBTables).GetPage(tx, 10, 1)
+		},
+		"DBTables.Get": func(tx *gorm.DB) {
+			_, _ = (&DBTables{TableName: "sys_user"}).Get(tx)
+		},
+		"DBColumns.GetPage": func(tx *gorm.DB) {
+			_, _, _ = (&DBColumns{TableName: "sys_user"}).GetPage(tx, 10, 1)
+		},
+		"DBColumns.GetList": func(tx *gorm.DB) {
+			_, _ = (&DBColumns{TableName: "sys_user"}).GetList(tx)
+		},
+	}
+
+	for name, call := range cases {
+		t.Run(name, func(t *testing.T) {
+			defer func() {
+				raised := recover()
+				if raised == nil {
+					t.Fatal("driver is not mysql and the call went through anyway")
+				}
+				msg, ok := raised.(string)
+				if !ok || !strings.Contains(msg, "目前只支持mysql数据库") {
+					t.Fatalf("want the mysql-only assertion, got %v", raised)
+				}
+			}()
+			call(nil)
+		})
+	}
+}

--- a/common/database/driver.go
+++ b/common/database/driver.go
@@ -1,0 +1,34 @@
+package database
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"gorm.io/gorm"
+)
+
+// openerFor resolves the gorm dialector registered for driver.
+//
+// Which drivers exist depends on how the binary was built: sqlite3 needs cgo
+// and is only compiled in under the sqlite3 build tag. A configuration naming a
+// driver this build does not carry used to reach gorm.Open with a nil function,
+// which is a nil dereference deep in the stack rather than an answer.
+func openerFor(driver string) (func(string) gorm.Dialector, error) {
+	open, ok := opens[driver]
+	if !ok {
+		return nil, fmt.Errorf("unsupported database driver %q, this build supports %s",
+			driver, strings.Join(supportedDrivers(), ", "))
+	}
+	return open, nil
+}
+
+// supportedDrivers lists what this build can open, in a stable order.
+func supportedDrivers() []string {
+	names := make([]string, 0, len(opens))
+	for name := range opens {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}

--- a/common/database/driver_test.go
+++ b/common/database/driver_test.go
@@ -1,0 +1,32 @@
+package database
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestOpenerForRejectsADriverThisBuildDoesNotCarry(t *testing.T) {
+	open, err := openerFor("sqlite")
+	if err == nil {
+		t.Fatalf("misspelled driver was accepted, opener is %v", open != nil)
+	}
+	// The message has to name the alternatives: the reader is looking at a
+	// config file and needs to know what to put there.
+	for _, want := range supportedDrivers() {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error does not mention the %s driver: %s", want, err)
+		}
+	}
+}
+
+func TestOpenerForResolvesTheBuiltInDrivers(t *testing.T) {
+	for _, driver := range []string{"mysql", "postgres", "sqlserver"} {
+		open, err := openerFor(driver)
+		if err != nil {
+			t.Fatalf("%s must be available in every build: %s", driver, err)
+		}
+		if open == nil {
+			t.Fatalf("%s resolved to a nil opener", driver)
+		}
+	}
+}

--- a/common/database/initialize.go
+++ b/common/database/initialize.go
@@ -37,6 +37,11 @@ func setupSimpleDatabase(host string, c *toolsConfig.Database) {
 			c.Registers[i].Policy,
 			c.Registers[i].Tables)
 	}
+	open, err := openerFor(c.Driver)
+	if err != nil {
+		log.Fatal(pkg.Red(err.Error()))
+	}
+
 	resolverConfig := toolsDB.NewConfigure(c.Source, c.MaxIdleConns, c.MaxOpenConns, c.ConnMaxIdleTime, c.ConnMaxLifeTime, registers)
 	db, err := resolverConfig.Init(&gorm.Config{
 		NamingStrategy: schema.NamingStrategy{
@@ -50,7 +55,7 @@ func setupSimpleDatabase(host string, c *toolsConfig.Database) {
 					log.DefaultLogger.Options().Level.LevelForGorm()),
 			},
 		),
-	}, opens[c.Driver])
+	}, open)
 
 	if err != nil {
 		log.Fatal(pkg.Red(c.Driver+" connect error :"), err)

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/bytedance/go-tagexpr/v2 v2.9.11
 	github.com/casbin/casbin/v3 v3.8.1
 	github.com/gin-gonic/gin v1.12.0
+	github.com/glebarez/sqlite v1.11.0
 	github.com/go-admin-team/go-admin-core v1.7.1-0.20260818135152-a912b404d5c0
 	github.com/google/uuid v1.6.0
 	github.com/huaweicloud/huaweicloud-sdk-go-obs v3.26.6+incompatible
@@ -31,6 +32,7 @@ require (
 	gorm.io/driver/sqlite v1.6.0
 	gorm.io/driver/sqlserver v1.6.4
 	gorm.io/gorm v1.31.2
+	gorm.io/plugin/soft_delete v1.2.1
 )
 
 require (
@@ -58,7 +60,6 @@ require (
 	github.com/ghodss/yaml v1.0.0 // indirect
 	github.com/gin-contrib/sse v1.1.1 // indirect
 	github.com/glebarez/go-sqlite v1.22.0 // indirect
-	github.com/glebarez/sqlite v1.11.0 // indirect
 	github.com/go-ole/go-ole v1.2.6 // indirect
 	github.com/go-openapi/jsonpointer v1.0.0 // indirect
 	github.com/go-openapi/jsonreference v1.0.0 // indirect
@@ -141,7 +142,6 @@ require (
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gorm.io/plugin/dbresolver v1.6.2 // indirect
-	gorm.io/plugin/soft_delete v1.2.1 // indirect
 	modernc.org/fileutil v1.3.40 // indirect
 	modernc.org/libc v1.67.4 // indirect
 	modernc.org/mathutil v1.7.1 // indirect


### PR DESCRIPTION
Four of the code generator's guards do the opposite of what they say, and one of them has been reported before: #223 (2020) carried the same two-line fix and was closed unmerged, #718/#658 (2022) and #711 (2022) likewise.

### The columns endpoint rejected exactly the valid requests

`pkg.Assert` panics when its condition is **false**. `Assert(TableName == "", "table name cannot be empty")` therefore rejected every request that carried a table name and let the empty one through. The model layer repeated the inversion as `if TableName != "" { return error }`, so `GET /api/v1/db/columns/page` could not return columns either way.

The correct form was ten lines below the whole time, in `GetList`.

### The mysql-only guard never fired

`pkg.Assert(true, "目前只支持mysql数据库")` is a no-op, in three places. On postgres or sqlserver the generator did not report that it needs MySQL:

- `DBTables` returned an empty list with a nil error, so the UI showed "no tables"
- `DBColumns` ran its query on the zero-value `*gorm.DB` left by the branch that never assigned, which is a nil dereference

The assertion now names the real condition up front, which also removes the placeholder `*gorm.DB` the fall-through relied on. `DBColumns.GetPage` had no guard at all and gets the same one.

### An unknown driver panicked instead of saying so

`opens` is a map, so `opens[c.Driver]` on a driver this build does not carry hands `gorm.Open` a nil function to call. sqlite3 is the case that bites: it needs cgo and only compiles in under the `sqlite3` build tag, so one config file works on one binary and dies on another with a nil dereference inside gorm.

#718 proposed dropping the build tag, which would put the cgo dependency in every build. Resolving the driver first and naming what this build supports keeps the tag.

### The candidate table query assumed one database

The exclusion list was a subquery against `` `$GenConfig.DBName`.sys_tables ``, naming the schema by hand: generating from a schema that does not hold `sys_tables` failed outright. Reading the table directly also counted soft-deleted rows, so deleting a generator entry never handed its table back.

It now reads the registrations through the model on this connection. An empty list skips the clause — `NOT IN (NULL)` is unknown for every row, which would leave a fresh install with nothing to generate from.

### Tests

Every fix has a test that goes red when the fix is reverted:

| reverted to | goes red |
|---|---|
| either inverted guard | `TestGetDBColumnList_AcceptsATableName` |
| `Assert(true, ...)` | all four subtests of `TestCodegenModelsRefuseNonMySQLDrivers`, two of them reporting the nil dereference |
| `opens[driver]` | `TestOpenerForRejectsADriverThisBuildDoesNotCarry` |
| the hand-written schema | all three `TestGetPage*` |
| an unscoped read | `TestGetPageOffersTablesWhoseEntryWasDeleted` |
| dropping the empty-list guard | `TestGetPageListsEveryTableWhenNoneAreRegistered`, with zero tables offered |

`DBTables.GetPage` is covered by attaching an in-memory database called `information_schema` to sqlite, so the production query runs unchanged.

`make build` and `go mod tidy` are clean. `common/file_store` fails on master too; it needs OBS credentials.