### PR TITLE
docs📝: repoint the README links that stopped resolving

### DIFF
--- a/README.Zh-cn.md
+++ b/README.Zh-cn.md
@@ -78,9 +78,9 @@ antd 体验（go-admin-pro）：[https://antd.go-admin.pro](https://antd.go-admi
 
 ### 轻松实现go-admin写出第一个应用 - 文档教程
 
-[步骤一 - 基础内容介绍](https://doc.zhangwj.com/guide/intro/tutorial01.html)
+[步骤一 - 基础内容介绍](https://doc.go-admin.dev/guide/intro/tutorial01.html)
 
-[步骤二 - 实际应用 - 编写增删改查](https://doc.zhangwj.com/guide/intro/tutorial02.html)
+[步骤二 - 实际应用 - 编写增删改查](https://doc.go-admin.dev/guide/intro/tutorial02.html)
 
 ### 手把手教你从入门到放弃 - 视频教程
 
@@ -329,7 +329,7 @@ pnpm dev
 6. [spf13/viper](https://github.com/spf13/viper)
 7. [gorm](https://github.com/jinzhu/gorm)
 8. [gin-swagger](https://github.com/swaggo/gin-swagger)
-9. [jwt-go](https://github.com/dgrijalva/jwt-go)
+9. [golang-jwt](https://github.com/golang-jwt/jwt)
 10. [vue-element-admin](https://github.com/PanJiaChen/vue-element-admin)
 11. [ruoyi-vue](https://gitee.com/y_project/RuoYi-Vue)
 12. [form-generator](https://github.com/JakHuang/form-generator)
@@ -343,10 +343,10 @@ pnpm dev
 
 ## 🤝 链接
 
-[Go开发者成长线路图](http://www.golangroadmap.com/)
+- [mss-boot-io](https://docs.mss-boot-io.top/)
 
 ## 🔑 License
 
 [MIT](https://github.com/go-admin-team/go-admin/blob/master/LICENSE.md)
 
-Copyright (c) 2024 wenjianzhang
+Copyright (c) 2026 wenjianzhang

--- a/README.md
+++ b/README.md
@@ -21,10 +21,10 @@ The front-end and back-end separation authority management system based on Gin +
 ## 🎬 Online Demo
 
 Element Plus vue3 demo：[https://vue.go-admin.pro](https://vue.go-admin.pro/#/login)
-> 账号 / 密码： admin / 123456
+> Account / Password: admin / 123456
 
 antd demo (go-admin-pro)：[https://antd.go-admin.pro](https://antd.go-admin.pro/)
-> 账号 / 密码： admin / 123456
+> Account / Password: admin / 123456
 > 
 ## ✨ Feature
 
@@ -76,9 +76,9 @@ At the same time, a series of tutorials including videos and documents are provi
 
 ### Easily implement go-admin to write the first application-documentation tutorial
 
-[Step 1 - basic content introduction](https://doc.zhangwj.com/guide/intro/tutorial01.html)
+[Step 1 - basic content introduction](https://doc.go-admin.dev/guide/intro/tutorial01.html)
 
-[Step 2 - Practical application - writing database operations](https://doc.zhangwj.com/guide/intro/tutorial02.html)
+[Step 2 - Practical application - writing database operations](https://doc.go-admin.dev/guide/intro/tutorial02.html)
 
 ### Teach you from getting started to giving up-video tutorial
 
@@ -320,7 +320,7 @@ The `go-admin` project has always been developed in the GoLand integrated develo
 2. [spf13/viper](https://github.com/spf13/viper)
 2. [gorm](https://github.com/jinzhu/gorm)
 2. [gin-swagger](https://github.com/swaggo/gin-swagger)
-2. [jwt-go](https://github.com/dgrijalva/jwt-go)
+2. [golang-jwt](https://github.com/golang-jwt/jwt)
 2. [vue-element-admin](https://github.com/PanJiaChen/vue-element-admin)
 2. [ruoyi-vue](https://gitee.com/y_project/RuoYi-Vue)
 2. [form-generator](https://github.com/JakHuang/form-generator)
@@ -332,11 +332,10 @@ The `go-admin` project has always been developed in the GoLand integrated develo
 <img class="no-margin" src="https://raw.githubusercontent.com/wenjianzhang/image/master/img/pay.png"  height="200px" >
 
 ## 🤝 Link
-- [Go developer growth roadmap](http://www.golangroadmap.com/)
 - [mss-boot-io](https://docs.mss-boot-io.top/)
 
 ## 🔑 License
 
 [MIT](https://github.com/go-admin-team/go-admin/blob/master/LICENSE.md)
 
-Copyright (c) 2022 wenjianzhang
+Copyright (c) 2026 wenjianzhang


### PR DESCRIPTION
| link | status | now |
|---|---|---|
| `doc.zhangwj.com/guide/intro/tutorial01.html` | does not answer | `doc.go-admin.dev`, same paths |
| `doc.zhangwj.com/guide/intro/tutorial02.html` | does not answer | `doc.go-admin.dev`, same paths |
| `www.golangroadmap.com` | 503 | dropped |
| `dgrijalva/jwt-go` | archived years ago | `golang-jwt/jwt`, which is what this project builds on |

Also: the copyright years read 2022 (English) and 2024 (Chinese); the English README asked for a password in Chinese; and removing the dead roadmap link left the Chinese README's link section empty, so it gets the `mss-boot-io` entry the English side already had.

All 133 links in both files were checked. Every link touched here returns 2xx.

**Not changed:** five contributor profile links return 404 because those accounts were renamed or deleted. The avatars still resolve — they are keyed by user id — and the contributions happened, so the entries stay.