### PR TITLE
ci🔧: run one deploy at a time

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,14 @@ on:
   pull_request:
     branches: [ master ]
 
+# One deploy at a time. Two merges seconds apart raced here: both runs did
+# docker rm -f then docker run, the second removed the container the first had
+# just created, and the first's docker run then failed on a name conflict -
+# leaving the demo on the older image with a red deploy.
+concurrency:
+  group: deploy-${{ github.ref }}
+  cancel-in-progress: false
+
 env:
   IMAGE_NAME: registry.ap-northeast-1.aliyuncs.com/go-admin/go-admin-api # 镜像名称
   TAG: ${{ github.sha }}


### PR DESCRIPTION
Merging #872 and #873 seconds apart produced this:

```
docker: Error response from daemon: Conflict.
The container name "/go-admin-api" is already in use by container "9ba1e8dd..."
Process exited with status 125
```

Both runs do `docker rm -f go-admin-api` and then `docker run --name go-admin-api`. The second run removed the container the first had just created; the first's `docker run` then hit the name conflict and the deploy went red — leaving the demo on the **older** image, which is the worse half of the failure. A red deploy that also rolled back would be honest; this one left the wrong version running and said so only in the workflow log.

`concurrency` grouped by `github.ref` serialises pushes to master. Pull request runs carry their own ref, so they stay independent of each other and of master. `cancel-in-progress` is false deliberately: a deploy in the middle of restarting a container should finish, not be killed.

This does not fix the underlying shape — `rm -f` before `run`, with no health check and nothing to roll back to — which is tracked in #871 along with the missing migration step.