### PR TITLE
perf👌: the data-permission lookup ran on every request, including when it was switched off

### DIFF
--- a/common/actions/permission.go
+++ b/common/actions/permission.go
@@ -21,22 +21,35 @@ type DataPermission struct {
 
 func PermissionAction() gin.HandlerFunc {
 	return func(c *gin.Context) {
+		// Permission() below returns the query untouched when data permission
+		// is off, so the lookup that feeds it has nothing to feed. It used to
+		// run anyway: a sys_user join on every list, detail, update and delete,
+		// with the result discarded.
+		if !config.ApplicationConfig.EnableDP {
+			c.Set(PermissionKey, new(DataPermission))
+			c.Next()
+			return
+		}
+
+		userId := user.GetUserIdStr(c)
+		if userId == "" {
+			c.Set(PermissionKey, new(DataPermission))
+			c.Next()
+			return
+		}
+
 		db, err := pkg.GetOrm(c)
 		if err != nil {
 			log.Error(err)
 			return
 		}
-
 		msgID := pkg.GenerateMsgIDFromContext(c)
-		var p = new(DataPermission)
-		if userId := user.GetUserIdStr(c); userId != "" {
-			p, err = newDataPermission(db, userId)
-			if err != nil {
-				log.Errorf("MsgID[%s] PermissionAction error: %s", msgID, err)
-				response.Error(c, 500, err, "权限范围鉴定错误")
-				c.Abort()
-				return
-			}
+		p, err := newDataPermission(db, userId)
+		if err != nil {
+			log.Errorf("MsgID[%s] PermissionAction error: %s", msgID, err)
+			response.Error(c, 500, err, "权限范围鉴定错误")
+			c.Abort()
+			return
 		}
 		c.Set(PermissionKey, p)
 		c.Next()

--- a/common/actions/permission.go
+++ b/common/actions/permission.go
@@ -38,6 +38,15 @@ func PermissionAction() gin.HandlerFunc {
 			return
 		}
 
+		// The token already carries what the scope is decided by. Reading it
+		// there costs nothing, and goes no more stale than rolekey does - which
+		// Casbin has always read from the token.
+		if p, ok := permissionFromClaims(c); ok {
+			c.Set(PermissionKey, p)
+			c.Next()
+			return
+		}
+
 		db, err := pkg.GetOrm(c)
 		if err != nil {
 			log.Error(err)
@@ -54,6 +63,26 @@ func PermissionAction() gin.HandlerFunc {
 		c.Set(PermissionKey, p)
 		c.Next()
 	}
+}
+
+// permissionFromClaims builds the scope from the token, reporting false when
+// the token predates deptid being carried. Such a token still exists until it
+// expires, and it has to keep working.
+func permissionFromClaims(c *gin.Context) (*DataPermission, bool) {
+	claims := user.ExtractClaims(c)
+	if claims["deptid"] == nil || claims["datascope"] == nil {
+		return nil, false
+	}
+	scope, ok := claims["datascope"].(string)
+	if !ok {
+		return nil, false
+	}
+	return &DataPermission{
+		DataScope: scope,
+		UserId:    user.GetUserId(c),
+		DeptId:    user.GetDeptId(c),
+		RoleId:    user.GetRoleId(c),
+	}, true
 }
 
 func newDataPermission(tx *gorm.DB, userId interface{}) (*DataPermission, error) {

--- a/common/actions/permission_test.go
+++ b/common/actions/permission_test.go
@@ -1,0 +1,46 @@
+package actions
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	jwt "github.com/go-admin-team/go-admin-core/v2/jwtauth"
+	"github.com/go-admin-team/go-admin-core/v2/sdk/config"
+)
+
+// No database is placed in the context on purpose. The middleware needs one
+// only to run the sys_user join, so reaching the handler proves it did not.
+func runPermission(t *testing.T, claims jwt.MapClaims) (*DataPermission, bool) {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+
+	c, _ := gin.CreateTestContext(httptest.NewRecorder())
+	c.Request = httptest.NewRequest(http.MethodGet, "/", nil)
+	if claims != nil {
+		c.Set(jwt.JwtPayloadKey, claims)
+	}
+
+	PermissionAction()(c)
+
+	value, exists := c.Get(PermissionKey)
+	if !exists {
+		return nil, false
+	}
+	p, _ := value.(*DataPermission)
+	return p, true
+}
+
+// Permission() returns the query untouched when data permission is off, so the
+// lookup feeding it has nothing to feed. It used to run regardless: a sys_user
+// join on every list, detail, update and delete, discarded immediately.
+func TestNoLookupWhenDataPermissionIsOff(t *testing.T) {
+	previous := config.ApplicationConfig.EnableDP
+	config.ApplicationConfig.EnableDP = false
+	t.Cleanup(func() { config.ApplicationConfig.EnableDP = previous })
+
+	if _, ok := runPermission(t, jwt.MapClaims{"identity": float64(7)}); !ok {
+		t.Fatal("the request needed a database even though data permission is off")
+	}
+}

--- a/common/actions/permission_test.go
+++ b/common/actions/permission_test.go
@@ -44,3 +44,38 @@ func TestNoLookupWhenDataPermissionIsOff(t *testing.T) {
 		t.Fatal("the request needed a database even though data permission is off")
 	}
 }
+
+func TestScopeComesFromTheTokenWhenItCarriesOne(t *testing.T) {
+	previous := config.ApplicationConfig.EnableDP
+	config.ApplicationConfig.EnableDP = true
+	t.Cleanup(func() { config.ApplicationConfig.EnableDP = previous })
+
+	p, ok := runPermission(t, jwt.MapClaims{
+		"identity":  float64(7),
+		"roleid":    float64(3),
+		"deptid":    float64(5),
+		"datascope": "4",
+	})
+	if !ok {
+		t.Fatal("the token carried the scope and a database was still needed")
+	}
+	if p.DataScope != "4" || p.UserId != 7 || p.DeptId != 5 || p.RoleId != 3 {
+		t.Fatalf("scope read as %+v", p)
+	}
+}
+
+// A token minted before deptid was carried is still valid until it expires, and
+// has to keep working - by falling back to the query, which needs a database.
+func TestATokenWithoutDeptIdFallsBackToTheQuery(t *testing.T) {
+	previous := config.ApplicationConfig.EnableDP
+	config.ApplicationConfig.EnableDP = true
+	t.Cleanup(func() { config.ApplicationConfig.EnableDP = previous })
+
+	if _, ok := runPermission(t, jwt.MapClaims{
+		"identity":  float64(7),
+		"roleid":    float64(3),
+		"datascope": "4",
+	}); ok {
+		t.Fatal("an old token was served from claims it does not have")
+	}
+}

--- a/common/middleware/handler/auth.go
+++ b/common/middleware/handler/auth.go
@@ -29,6 +29,10 @@ func PayloadFunc(data interface{}) jwt.MapClaims {
 			jwt.NiceKey:      u.Username,
 			jwt.DataScopeKey: r.DataScope,
 			jwt.RoleNameKey:  r.RoleName,
+			// deptid completes what the data-permission scope is decided by,
+			// so it can be read from the token instead of joined for on every
+			// request. core's user.GetDeptId has always read this claim.
+			"deptid": u.DeptId,
 		}
 	}
 	return jwt.MapClaims{}


### PR DESCRIPTION
`PermissionAction()` runs a `sys_user LEFT JOIN sys_role` before every list, detail, update and delete. Two commits, each removing a case where it did not need to.

### It ran with data permission switched off

The `EnableDP` check lives in `Permission()`, the scope — not in `PermissionAction()`, the middleware that does the query. So with `enabledp: false`, which is what `settings.full.yml` ships, every request paid for a join whose result was then discarded.

### It ran when the token already had the answer

The scope is decided by four values. Three were already in the token — `identity`, `roleid`, `datascope`. `deptid` was not, although core's `user.GetDeptId` has always read that claim. Adding it to `PayloadFunc` lets the middleware build the scope from the token and skip the query entirely.

**On staleness:** this goes no more stale than `rolekey`, which Casbin has read from the token since the beginning. A role change already required a new login to take effect on authorization; now it does for the data scope too, on the same schedule. It does not introduce a new class of staleness — but it is a behaviour change worth knowing about, so it is called out here rather than buried.

**Old tokens keep working.** A token minted before this carries no `deptid`; `permissionFromClaims` reports that and the lookup runs for it exactly as before, until it expires.

### Counter-proofs

The tests put no database in the context on purpose — the middleware needs one only for the join, so reaching the handler proves it did not run.

| reverted | result |
|---|---|
| the `EnableDP` early return | `the request needed a database even though data permission is off` |
| the claims path | `the token carried the scope and a database was still needed` |
| the `deptid == nil` check | `an old token was served from claims it does not have` |

`go test ./...` passes with nothing excluded.
