### PR TITLE
fix🐛: MySQL installs could not log in — the migration run stopped at a tinyint overflow

### DIFF
--- a/cmd/migrate/migration/version/1786700001000_demo_menu.go
+++ b/cmd/migrate/migration/version/1786700001000_demo_menu.go
@@ -56,7 +56,10 @@ func _1786700001000DemoMenu(db *gorm.DB, version string) error {
 		dir := models.SysMenu{
 			MenuId: demoMenuId, MenuName: "Demo", Title: "示例模块", Icon: "example",
 			Path: "/demo", Paths: "/0/9000", MenuType: "M", ParentId: 0,
-			Component: "Layout", Sort: 900, Visible: "0", IsFrame: "1",
+			// sort is `gorm:"size:4"`, which MySQL builds as a tinyint - anything
+			// over 127 is rejected outright. The seeded menus run to 100, so 110
+			// still puts this last.
+			Component: "Layout", Sort: 110, Visible: "0", IsFrame: "1",
 		}
 		if err := upsert(tx, &models.SysMenu{}, "menu_id = ?", dir.MenuId, &dir); err != nil {
 			return err

--- a/cmd/migrate/migration/version/1786700004000_generator_tables_marker.go
+++ b/cmd/migrate/migration/version/1786700004000_generator_tables_marker.go
@@ -1,0 +1,40 @@
+package version
+
+import (
+	"fmt"
+	"runtime"
+
+	"gorm.io/gorm"
+
+	"go-admin/cmd/migrate/migration"
+	common "go-admin/common/models"
+)
+
+// Convert the two generator tables to the same delete marker every other table
+// got in 1786700003000.
+//
+// They were left out of that list, and the mismatch is invisible until it is
+// not: the tables are built from cmd/migrate/migration/models, whose ModelTime
+// still carries a nullable gorm.DeletedAt, while the runtime models in
+// app/other/models/tools embed common.ModelTime, which is the millisecond
+// marker. GORM therefore queries them with deleted_at = 0 against a datetime
+// column holding NULL, and every row is invisible - so the code generator
+// listed no tables at all.
+//
+// tb_demo has the same shape and is deliberately not here: nothing reads it at
+// runtime, so there is no mismatch to fix.
+func init() {
+	_, fileName, _, _ := runtime.Caller(0)
+	migration.Migrate.SetVersion(migration.GetFilename(fileName), _1786700004000GeneratorTablesMarker)
+}
+
+var generatorTables = []string{"sys_columns", "sys_tables"}
+
+func _1786700004000GeneratorTablesMarker(db *gorm.DB, version string) error {
+	for _, table := range generatorTables {
+		if err := convertDeletedAt(db, table); err != nil {
+			return fmt.Errorf("%s: %w", table, err)
+		}
+	}
+	return db.Create(&common.Migration{Version: version}).Error
+}

--- a/cmd/migrate/migration/version/column_width_test.go
+++ b/cmd/migrate/migration/version/column_width_test.go
@@ -1,0 +1,82 @@
+package version
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"math"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// Fields tagged gorm:"size:4" become a tinyint on MySQL, which holds -128..127.
+// sqlite ignores the width, so a value that overflows passes every local test
+// and fails on a real install - and because the migration is not transactional,
+// it fails partway, leaving later migrations unapplied.
+//
+// That is what happened: a seeded menu with Sort: 900 stopped the run at
+// 1786700001000, so the soft-delete conversion never ran, deleted_at stayed
+// NULL, and nobody could log in.
+var narrowColumns = map[string]struct{ min, max int64 }{
+	"Sort":   {math.MinInt8, math.MaxInt8},
+	"Status": {math.MinInt8, math.MaxInt8},
+}
+
+func TestSeededValuesFitTheirColumns(t *testing.T) {
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	files, err := filepath.Glob(filepath.Join(dir, "*.go"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	checked := 0
+	for _, path := range files {
+		if strings.HasSuffix(path, "_test.go") {
+			continue
+		}
+		fset := token.NewFileSet()
+		f, err := parser.ParseFile(fset, path, nil, 0)
+		if err != nil {
+			t.Fatalf("parse %s: %v", path, err)
+		}
+		ast.Inspect(f, func(n ast.Node) bool {
+			kv, ok := n.(*ast.KeyValueExpr)
+			if !ok {
+				return true
+			}
+			key, ok := kv.Key.(*ast.Ident)
+			if !ok {
+				return true
+			}
+			limits, watched := narrowColumns[key.Name]
+			if !watched {
+				return true
+			}
+			lit, ok := kv.Value.(*ast.BasicLit)
+			if !ok || lit.Kind != token.INT {
+				return true
+			}
+			v, err := strconv.ParseInt(lit.Value, 10, 64)
+			if err != nil {
+				return true
+			}
+			checked++
+			if v < limits.min || v > limits.max {
+				t.Errorf("%s:%d: %s: %d does not fit a tinyint (%d..%d);\n"+
+					"    MySQL rejects it with Error 1264 and the migration stops there",
+					filepath.Base(path), fset.Position(lit.Pos()).Line, key.Name, v, limits.min, limits.max)
+			}
+			return true
+		})
+	}
+
+	if checked == 0 {
+		t.Fatal("no seeded values were examined; the scan is broken, not the code")
+	}
+}

--- a/cmd/migrate/migration/version/schema_coverage_test.go
+++ b/cmd/migrate/migration/version/schema_coverage_test.go
@@ -1,0 +1,173 @@
+package version
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// The repository carries two ModelTime types. The one in
+// cmd/migrate/migration/models still has a nullable gorm.DeletedAt and is what
+// builds the tables; the one in common/models is the millisecond marker and is
+// what queries them. A table whose runtime model embeds the second but which no
+// migration converts is queried with deleted_at = 0 against a datetime column,
+// and every row is invisible - silently, and only in production.
+//
+// sys_columns and sys_tables were in exactly that state: the code generator
+// listed no tables at all.
+func TestEveryRuntimeSoftDeleteTableIsConverted(t *testing.T) {
+	converted := map[string]bool{}
+	for _, name := range append(append([]string{}, softDeleteTables...), generatorTables...) {
+		converted[name] = true
+	}
+
+	// tb_demo is built with the marker-less model and has no runtime model at
+	// all, so nothing ever queries it with deleted_at = 0.
+	const noRuntimeModel = "tb_demo"
+
+	for table, file := range runtimeSoftDeleteTables(t) {
+		if table == noRuntimeModel {
+			continue
+		}
+		if !converted[table] {
+			t.Errorf("%s (%s) embeds common.ModelTime but no migration converts its deleted_at;\n"+
+				"    it will be queried with deleted_at = 0 against a nullable datetime and return nothing",
+				table, file)
+		}
+	}
+}
+
+// runtimeSoftDeleteTables maps table name to the file declaring it, for every
+// model under app/ that embeds the marker-carrying ModelTime.
+func runtimeSoftDeleteTables(t *testing.T) map[string]string {
+	t.Helper()
+
+	root := repoRoot(t)
+	found := map[string]string{}
+
+	err := filepath.Walk(filepath.Join(root, "app"), func(path string, info os.FileInfo, err error) error {
+		if err != nil || info.IsDir() || !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return err
+		}
+		fset := token.NewFileSet()
+		f, err := parser.ParseFile(fset, path, nil, 0)
+		if err != nil {
+			return nil // not this test's business
+		}
+		// Only files importing the runtime models package can embed its ModelTime.
+		if !importsRuntimeModels(f) {
+			return nil
+		}
+		for name, table := range tablesWithModelTime(f) {
+			_ = name
+			found[table] = strings.TrimPrefix(path, root+"/")
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk app/: %v", err)
+	}
+	if len(found) == 0 {
+		t.Fatal("found no runtime models at all; the scan is broken, not the code")
+	}
+	return found
+}
+
+func importsRuntimeModels(f *ast.File) bool {
+	for _, imp := range f.Imports {
+		p, err := strconv.Unquote(imp.Path.Value)
+		if err == nil && p == "go-admin/common/models" {
+			return true
+		}
+	}
+	return false
+}
+
+// tablesWithModelTime returns struct name -> table name for structs that embed
+// ModelTime and declare a TableName.
+func tablesWithModelTime(f *ast.File) map[string]string {
+	embeds := map[string]bool{}
+	ast.Inspect(f, func(n ast.Node) bool {
+		ts, ok := n.(*ast.TypeSpec)
+		if !ok {
+			return true
+		}
+		st, ok := ts.Type.(*ast.StructType)
+		if !ok {
+			return true
+		}
+		for _, field := range st.Fields.List {
+			if len(field.Names) != 0 {
+				continue // named field, not an embed
+			}
+			if sel, ok := field.Type.(*ast.SelectorExpr); ok && sel.Sel.Name == "ModelTime" {
+				embeds[ts.Name.Name] = true
+			}
+		}
+		return true
+	})
+
+	out := map[string]string{}
+	for name := range embeds {
+		if table := tableNameOf(f, name); table != "" {
+			out[name] = table
+		}
+	}
+	return out
+}
+
+// tableNameOf finds the string returned by func (T) TableName() string.
+func tableNameOf(f *ast.File, structName string) string {
+	var table string
+	ast.Inspect(f, func(n ast.Node) bool {
+		fn, ok := n.(*ast.FuncDecl)
+		if !ok || fn.Name.Name != "TableName" || fn.Recv == nil || len(fn.Recv.List) != 1 {
+			return true
+		}
+		if receiverName(fn.Recv.List[0].Type) != structName {
+			return true
+		}
+		ast.Inspect(fn.Body, func(n ast.Node) bool {
+			lit, ok := n.(*ast.BasicLit)
+			if ok && lit.Kind == token.STRING {
+				if s, err := strconv.Unquote(lit.Value); err == nil && table == "" {
+					table = s
+				}
+			}
+			return true
+		})
+		return true
+	})
+	return table
+}
+
+func receiverName(expr ast.Expr) string {
+	switch t := expr.(type) {
+	case *ast.Ident:
+		return t.Name
+	case *ast.StarExpr:
+		return receiverName(t.X)
+	}
+	return ""
+}
+
+func repoRoot(t *testing.T) string {
+	t.Helper()
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < 8; i++ {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		dir = filepath.Dir(dir)
+	}
+	t.Fatal("go.mod not found above the test directory")
+	return ""
+}


### PR DESCRIPTION
Fixes the report that `admin` / `123456` cannot log in on a fresh install, with the correct password hash in the database and `deleted_at` NULL.

Reproduced on MySQL 8.4 in strict mode, which is the default. **sqlite installs are unaffected**, which is why this was not caught: sqlite ignores a declared column width.

### The migration run stopped partway, and nothing said so

`sort` is `gorm:"size:4"`, which MySQL builds as a **tinyint** — range -128..127. The demo menu seeds `Sort: 900`:

```
1786700001000_demo_menu.go:134
Error 1264 (22003): Out of range value for column 'sort' at row 1
```

The migration framework is deliberately not transactional (DDL does not roll back on MySQL), so the run stops there and every later migration is skipped:

```
sys_migration:  1599190683659, 1653638869132, 1786700000000
                                       ↑ 1786700001000 and everything after: never applied
```

The one that never ran is `1786700003000`, the soft-delete conversion. So `deleted_at` stayed NULL — put there by `config/db.sql`, which seeds 126 rows ending in `NULL` — while the code queries `deleted_at = 0`. The login returns *incorrect Username or Password* for a password that is correct.

### A second table set had the same shape

`sys_columns` and `sys_tables` were left out of the conversion list. Their runtime models embed `common.ModelTime` — the millisecond marker — so GORM queries them with `deleted_at = 0` against a nullable datetime. Verified against a real database: one row inserted, `WHERE deleted_at = 0` returns **0**. The code generator listed no tables at all.

The underlying reason is that the repository carries **two `ModelTime` types**:

| package | `DeletedAt` | role |
|---|---|---|
| `cmd/migrate/migration/models` | `gorm.DeletedAt` (nullable datetime) | builds the tables |
| `common/models` | `soft_delete.DeletedAt` (bigint marker) | queries them |

Nothing connected them, so a table could be built one way and read the other with no signal.

### Verified end to end on MySQL 8.4

| path | before | after |
|---|---|---|
| fresh install | migrate exits 1, `can_login = 0` | 7 migrations applied, `can_login = 1` |
| upgrade from an old schema | `deleted_at` NULL, `can_login = 0` | NULL → 0, `can_login = 1`, `uk_sys_user_username` rebuilt over `(username, deleted_at)` |
| generator table list | `WHERE deleted_at = 0` returns 0 rows | returns the row |

### Two tests, neither needing a database

`TestSeededValuesFitTheirColumns` parses the migrations and rejects a `Sort`/`Status` outside tinyint range. Reverting `Sort` to 900:

```
1786700001000_demo_menu.go:62: Sort: 900 does not fit a tinyint (-128..127);
    MySQL rejects it with Error 1264 and the migration stops there
```

`TestEveryRuntimeSoftDeleteTableIsConverted` walks `app/` for models embedding the marker and requires a migration to cover each. Removing `sys_tables` from the list:

```
sys_tables (app/other/models/tools/sys_tables.go) embeds common.ModelTime but no
migration converts its deleted_at; it will be queried with deleted_at = 0 against
a nullable datetime and return nothing
```

### On editing an already-numbered migration

`1786700001000` is edited rather than superseded, which normally would not be allowed. It is the only option here: it **never completed on MySQL**, so it was never recorded, and any migration added after it would still be blocked behind it. On sqlite it did complete, and the change does not re-run — those installs keep `Sort: 900`, which only affects menu ordering.

`1786700004000` is a new migration rather than an edit to `1786700003000`, since that one did complete.

Existing installs still need `migrate` to be run — which is [#871](https://github.com/go-admin-team/go-admin/issues/871).
