### PR TITLE
ci🔧: run the demo on the managed database instead of a bundled sqlite file

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,7 +65,14 @@ jobs:
           username: ${{ secrets.SSH_USERNAME }}
           key: ${{ secrets.DEPLOY_KEY }}
           # 重启的脚本，根据自身情况做相应改动，一般要做的是migrate数据库以及重启服务器
+          #
+          # 配置从宿主机挂载，不使用镜像里的那份：演示站连的是托管 MySQL，
+          # 而 config/settings.demo.yml 会随仓库公开、也会打进镜像，凭据不能写在那里。
+          # 镜像里那份保持 sqlite，供 clone 仓库的人开箱即用。
           script: |
+            test -f /www/vue-demo/config/settings.yml || { echo "缺少 /www/vue-demo/config/settings.yml，中止部署"; exit 1; }
             sudo docker rm -f go-admin-api
             sudo docker login --username=${{ secrets.DOCKER_USERNAME }} registry.ap-northeast-1.aliyuncs.com --password=${{ secrets.DOCKER_PASSWORD }}
-            sudo docker run -d -p 8000:8000 --name go-admin-api ${{ env.IMAGE_NAME_TAG }}
+            sudo docker run -d -p 8000:8000 \
+              -v /www/vue-demo/config/settings.yml:/config/settings.yml:ro \
+              --name go-admin-api ${{ env.IMAGE_NAME_TAG }}


### PR DESCRIPTION
The demo ran on the sqlite file baked into the image. Every deploy reset it, and nothing about that setup resembled how anyone actually runs go-admin — which is why the MySQL-only fault in #877 reached users before it reached us.

### Where the config comes from

`config/settings.demo.yml` ships in a public repository and is copied into a public image, so a connection string cannot live there. The deploy mounts a config file from the host instead — the same pattern the other services on that machine already use — and the copy in the repository stays on sqlite, which is what a fresh clone should get.

The deploy refuses to start if the host config is missing, rather than silently falling back to the image's sqlite and appearing to succeed.

### Done before this PR

The demo database was on an older schema, in the state #877 describes: `deleted_at` a nullable datetime, and the login query matching nothing. It was migrated first, using the image already deployed (`aa2976ba`, which carries the #877 fix). Afterwards the login query matches, and the three natural keys carry their unique index over `(key, deleted_at)`.

A dump was taken first.

### Verified before merging

A second container was started on a spare port with the same mount, leaving the live one untouched:

```
mysql connect success !
POST /api/v1/login  →  200
```

The mount, the credentials and the migrated schema were all confirmed working before the deploy was changed. The demo also now runs under a database account scoped to its own schema.
