### PR TITLE
docs📝: fix the badges and links, add Traditional Chinese and Japanese READMEs

### DIFF
--- a/README.Zh-cn.md
+++ b/README.Zh-cn.md
@@ -7,7 +7,7 @@
 [![Release](https://img.shields.io/github/release/go-admin-team/go-admin.svg?style=flat-square)](https://github.com/go-admin-team/go-admin/releases)
 [![License](https://img.shields.io/github/license/go-admin-team/go-admin.svg)](https://github.com/go-admin-team/go-admin)
 
-[English](https://github.com/go-admin-team/go-admin/blob/master/README.md) | 简体中文
+[English](https://github.com/go-admin-team/go-admin/blob/master/README.md) | 简体中文 | [繁體中文](https://github.com/go-admin-team/go-admin/blob/master/README.zh-TW.md) | [日本語](https://github.com/go-admin-team/go-admin/blob/master/README.ja-JP.md)
 
 基于Gin + Vue + Element UI OR Arco Design OR Ant Design的前后端分离权限管理系统,系统初始化极度简单，只需要配置文件中，修改数据库连接，系统支持多指令操作，迁移指令可以让初始化数据库信息变得更简单，服务指令可以很简单的启动api服务
 

--- a/README.Zh-cn.md
+++ b/README.Zh-cn.md
@@ -3,9 +3,9 @@
   <img align="right" width="320" src="https://doc-image.zhangwj.com/img/go-admin.svg">
 
 
-[![Build Status](https://github.com/wenjianzhang/go-admin/workflows/build/badge.svg)](https://github.com/go-admin-team/go-admin)
+[![Build Status](https://github.com/go-admin-team/go-admin/actions/workflows/go.yml/badge.svg?branch=master)](https://github.com/go-admin-team/go-admin)
 [![Release](https://img.shields.io/github/release/go-admin-team/go-admin.svg?style=flat-square)](https://github.com/go-admin-team/go-admin/releases)
-[![License](https://img.shields.io/github/license/mashape/apistatus.svg)](https://github.com/go-admin-team/go-admin)
+[![License](https://img.shields.io/github/license/go-admin-team/go-admin.svg)](https://github.com/go-admin-team/go-admin)
 
 [English](https://github.com/go-admin-team/go-admin/blob/master/README.md) | 简体中文
 
@@ -78,9 +78,9 @@ antd 体验（go-admin-pro）：[https://antd.go-admin.pro](https://antd.go-admi
 
 ### 轻松实现go-admin写出第一个应用 - 文档教程
 
-[步骤一 - 基础内容介绍](https://doc.go-admin.dev/guide/intro/tutorial01.html)
+[步骤一 - 基础内容介绍](https://www.go-admin.pro/guide/intro/tutorial01.html)
 
-[步骤二 - 实际应用 - 编写增删改查](https://doc.go-admin.dev/guide/intro/tutorial02.html)
+[步骤二 - 实际应用 - 编写增删改查](https://www.go-admin.pro/guide/intro/tutorial02.html)
 
 ### 手把手教你从入门到放弃 - 视频教程
 
@@ -173,7 +173,7 @@ D:\Code\go-admin>go build
 cgo: exec gcc: exec: "gcc": executable file not found in %PATH%
 ```
 
-[解决cgo问题进入](https://doc.go-admin.dev/zh-CN/guide/faq#cgo-%E7%9A%84%E9%97%AE%E9%A2%98)
+[解决cgo问题进入](https://www.go-admin.pro/zh-CN/guide/faq#cgo-%E7%9A%84%E9%97%AE%E9%A2%98)
 
 
 #### 初始化数据库，以及服务启动
@@ -327,7 +327,7 @@ pnpm dev
 4. [gin](https://github.com/gin-gonic/gin)
 5. [casbin](https://github.com/casbin/casbin)
 6. [spf13/viper](https://github.com/spf13/viper)
-7. [gorm](https://github.com/jinzhu/gorm)
+7. [gorm](https://github.com/go-gorm/gorm)
 8. [gin-swagger](https://github.com/swaggo/gin-swagger)
 9. [golang-jwt](https://github.com/golang-jwt/jwt)
 10. [vue-element-admin](https://github.com/PanJiaChen/vue-element-admin)

--- a/README.ja-JP.md
+++ b/README.ja-JP.md
@@ -1,161 +1,163 @@
-
 # go-admin
 
-<img align="right" width="320" src="https://raw.githubusercontent.com/wenjianzhang/image/203c5930b9ed08d5cf2fcb4516b85e412f8e0e60/img/go-admin.svg">
+  <img align="right" width="320" src="https://doc-image.zhangwj.com/img/go-admin.svg">
 
 
 [![Build Status](https://github.com/go-admin-team/go-admin/actions/workflows/go.yml/badge.svg?branch=master)](https://github.com/go-admin-team/go-admin)
 [![Release](https://img.shields.io/github/release/go-admin-team/go-admin.svg?style=flat-square)](https://github.com/go-admin-team/go-admin/releases)
 [![License](https://img.shields.io/github/license/go-admin-team/go-admin.svg)](https://github.com/go-admin-team/go-admin)
 
-English | [简体中文](https://github.com/go-admin-team/go-admin/blob/master/README.Zh-cn.md) | [繁體中文](https://github.com/go-admin-team/go-admin/blob/master/README.zh-TW.md) | [日本語](https://github.com/go-admin-team/go-admin/blob/master/README.ja-JP.md)
+[English](https://github.com/go-admin-team/go-admin/blob/master/README.md) | [简体中文](https://github.com/go-admin-team/go-admin/blob/master/README.Zh-cn.md) | [繁體中文](https://github.com/go-admin-team/go-admin/blob/master/README.zh-TW.md) | 日本語
 
-The front-end and back-end separation authority management system based on Gin + Vue + Element UI OR Arco Design OR Ant Design is extremely simple to initialize the system. You only need to modify the database connection in the configuration file. The system supports multi-instruction operations. Migration instructions can make it easier to initialize database information. Service instructions It's easy to start the api service.
+Gin + Vue + Element UI / Arco Design / Ant Design による、フロントエンドとバックエンドを分離した権限管理システムです。初期化は非常に簡単で、設定ファイルのデータベース接続情報を変更するだけで動作します。複数のコマンドに対応しており、マイグレーションコマンドでデータベースの初期化が容易になり、サーバーコマンドで API を手軽に起動できます。
 
-[documentation](https://www.go-admin.pro)
+[オンラインドキュメント](https://www.go-admin.pro)
 
-[Front-end project](https://github.com/go-admin-team/go-admin-ui)
+[フロントエンドプロジェクト](https://github.com/go-admin-team/go-admin-ui)
 
-[Video tutorial](https://space.bilibili.com/565616721/channel/detail?cid=125737)
+[動画チュートリアル](https://space.bilibili.com/565616721/channel/detail?cid=125737)
 
-## 🎬 Online Demo
+## 🎬 オンラインデモ
 
-Element Plus vue3 demo：[https://vue.go-admin.pro](https://vue.go-admin.pro/#/login)
-> Account / Password: admin / 123456
+Element Plus vue3 デモ：[https://vue.go-admin.pro](https://vue.go-admin.pro/#/login)
+> ⚠️⚠️⚠️ アカウント / パスワード： admin / 123456
 
-antd demo (go-admin-pro)：[https://antd.go-admin.pro](https://antd.go-admin.pro/)
-> Account / Password: admin / 123456
-> 
-## ✨ Feature
+antd デモ（go-admin-pro）：[https://antd.go-admin.pro](https://antd.go-admin.pro/)
+> ⚠️⚠️⚠️ アカウント / パスワード： admin / 123456
 
-- Follow RESTful API design specifications
+## ✨ 特徴
 
-- Based on the GIN WEB API framework, it provides rich middleware support (user authentication, cross-domain, access log, tracking ID, etc.)
+- RESTful API の設計規約に準拠
 
-- RBAC access control model based on Casbin
+- GIN WEB API フレームワークをベースに、豊富なミドルウェアを提供（ユーザー認証、CORS、アクセスログ、トレース ID など）
 
-- JWT authentication
+- Casbin による RBAC アクセス制御モデル
 
-- Support Swagger documents (based on swaggo)
+- JWT 認証
 
-- Database storage based on GORM, which can expand multiple types of databases
+- Swagger ドキュメントに対応（swaggo ベース）
 
-- Simple model mapping of configuration files to quickly get the desired configuration
+- GORM によるデータベース永続化、複数種類のデータベースに拡張可能
 
-- Code generation tool
+- 設定ファイルからモデルへの単純なマッピングで、必要な設定をすぐに取得
 
-- Form builder
+- コード生成ツール
 
-- Multi-command mode
+- フォームビルダー
 
-- TODO: unit test
+- マルチコマンド方式
 
+- マルチテナント対応
 
-## 🎁 Internal
+- TODO: ユニットテスト
 
-1. User management: The user is the system operator, this function mainly completes the system user configuration.
-2. Department management: configure the system organization (company, department, group), and display the tree structure to support data permissions.
-3. Position management: configure the positions of system users.
-4. Menu management: configure the system menu, operation authority, button authority identification, interface authority, etc.
-5. Role management: Role menu permission assignment and role setting are divided into data scope permissions by organization.
-6. Dictionary management: Maintain some relatively fixed data frequently used in the system.
-7. Parameter management: dynamically configure common parameters for the system.
-8. Operation log: system normal operation log record and query; system abnormal information log record and query.
-9. Login log: The system login log record query contains login exceptions.
-1. Interface documentation: Automatically generate related api interface documents according to the business code.
-1. Code generation: According to the data table structure, generate the corresponding addition, deletion, modification, and check corresponding business, and the whole process of visual operation, so that the basic business can be implemented with zero code.
-1. Form construction: Customize the page style, drag and drop to realize the page layout.
-1. Service monitoring: View the basic information of some servers.
-1. Content management: demo function, including classification management and content management. You can refer to the easy to use quick start.
+## 🎁 標準機能
 
-## Ready to work
+1. マルチテナント：デフォルトで対応。データベース単位で分離し、1 データベースにつき 1 テナント。
+1. ユーザー管理：システムの操作者であるユーザーの設定を行います。
+2. 部門管理：組織構造（会社・部門・グループ）を設定します。ツリー構造で表示し、データ権限に対応します。
+3. 役職管理：ユーザーが担当する職務を設定します。
+4. メニュー管理：メニュー、操作権限、ボタン権限識別子、API 権限などを設定します。
+5. ロール管理：ロールへのメニュー権限の割り当て、および組織単位でのデータ範囲権限の設定を行います。
+6. 辞書管理：システム内で頻繁に使う固定的なデータを管理します。
+7. パラメータ管理：よく使うパラメータを動的に設定します。
+8. 操作ログ：正常系の操作ログと異常情報のログを記録・検索します。
+9. ログインログ：ログイン履歴を記録・検索します。ログイン異常も含みます。
+1. API ドキュメント：業務コードから API ドキュメントを自動生成します。
+1. コード生成：テーブル定義から CRUD 業務を生成します。すべて画面上で操作でき、基本的な業務をコードなしで実現できます。
+1. フォームビルダー：ページのスタイルをカスタマイズし、ドラッグ＆ドロップでレイアウトを作成します。
+1. サービス監視：サーバーの基本情報を確認します。
+1. コンテンツ管理：デモ機能。カテゴリ管理とコンテンツ管理を含み、入門用の参考実装として利用できます。
+1. スケジュールタスク：自動実行タスク。現在は API 呼び出しと関数呼び出しに対応しています。
 
-You need to install locally [go] [gin] [node](http://nodejs.org/) 和 [git](https://git-scm.com/)
+## 事前準備
 
-At the same time, a series of tutorials including videos and documents are provided. How to complete the downloading to the proficient use, it is strongly recommended that you read these tutorials before you practice this project! ! !
+ローカルに [go] [gin] [node](http://nodejs.org/) と [git](https://git-scm.com/) をインストールしてください。
 
-### Easily implement go-admin to write the first application-documentation tutorial
+ダウンロードから使いこなすまでを解説した動画とドキュメントのチュートリアルを用意しています。本プロジェクトを試す前に、まずこれらに目を通すことを強くおすすめします。
 
-[Step 1 - basic content introduction](https://www.go-admin.pro/guide/intro/tutorial01.html)
+### go-admin で最初のアプリケーションを作る - ドキュメント
 
-[Step 2 - Practical application - writing database operations](https://www.go-admin.pro/guide/intro/tutorial02.html)
+[ステップ 1 - 基礎の紹介](https://www.go-admin.pro/guide/intro/tutorial01.html)
 
-### Teach you from getting started to giving up-video tutorial
+[ステップ 2 - 実践 - CRUD を書く](https://www.go-admin.pro/guide/intro/tutorial02.html)
 
-[How to start go-admin](https://www.bilibili.com/video/BV1z5411x7JG)
+### 動画チュートリアル
 
-[Easily implement business using build tools](https://www.bilibili.com/video/BV1Dg4y1i79D)
+[go-admin の起動方法](https://www.bilibili.com/video/BV1z5411x7JG)
 
-[v1.1.0 version code generation tool-free your hands](https://www.bilibili.com/video/BV1N54y1i71P) [Advanced]
+[生成ツールで業務を手軽に実装する](https://www.bilibili.com/video/BV1Dg4y1i79D)
 
-[Explanation of multi-command startup mode and IDE configuration](https://www.bilibili.com/video/BV1Fg4y1q7ph)
+[v1.1.0 のコード生成ツール](https://www.bilibili.com/video/BV1N54y1i71P) [応用]
 
-[Configuration instructions for go-admin menu](https://www.bilibili.com/video/BV1Wp4y1D715) [Must see]
+[マルチコマンドでの起動方法と IDE 設定](https://www.bilibili.com/video/BV1Fg4y1q7ph)
 
-[How to configure menu information and interface information](https://www.bilibili.com/video/BV1zv411B7nG) [Must see]
+[go-admin のメニュー設定](https://www.bilibili.com/video/BV1Wp4y1D715) [必見]
 
-[go-admin permission configuration instructions](https://www.bilibili.com/video/BV1rt4y197d3) [Must see]
+[メニュー情報と API 情報の設定方法](https://www.bilibili.com/video/BV1zv411B7nG) [必見]
 
-[Instructions for use of go-admin data permissions](https://www.bilibili.com/video/BV1LK4y1s71e) [Must see]
+[go-admin の権限設定](https://www.bilibili.com/video/BV1rt4y197d3) [必見]
 
-**If you have any questions, please read the above-mentioned usage documents and articles first. If you are not satisfied, welcome to issue and pr. Video tutorials and documents are being updated continuously.**
+[go-admin のデータ権限](https://www.bilibili.com/video/BV1LK4y1s71e) [必見]
 
-## 📦 Local development
+**不明点はまず上記のドキュメントと記事をご確認ください。解決しない場合は issue や pr をお寄せください。動画とドキュメントは継続的に更新しています**
 
-### Environmental requirements
+## 📦 ローカル開発
+
+### 動作要件
 
 go 1.26.5
 
-nodejs: v22+ (v24 LTS recommended)
+node バージョン: v22 以上（v24 LTS 推奨）
 
-package manager: pnpm v9+ (the UI project uses pnpm)
+パッケージマネージャー: pnpm v9 以上（UI プロジェクトは pnpm を使用）
 
-### Development directory creation
+### 開発ディレクトリの作成
 
 ```bash
 
-# Create a development directory
+# 開発ディレクトリを作成
 mkdir goadmin
 cd goadmin
 ```
 
-### Get the code
+### コードの取得
 
-> Important note: the two projects must be placed in the same folder;
+> 重要：2 つのプロジェクトは同じディレクトリに配置してください。
 
 ```bash
-# Get backend code
+# バックエンドのコードを取得
 git clone https://github.com/go-admin-team/go-admin.git
 
-# Get the front-end code
+# フロントエンドのコードを取得
 git clone https://github.com/go-admin-team/go-admin-ui.git
 
 ```
 
-### Startup instructions
+### 起動方法
 
-#### Server startup instructions
+#### サーバーの起動
 
 ```bash
-# Enter the go-admin backend project
+# go-admin バックエンドプロジェクトへ移動
 cd ./go-admin
 
-# Update dependencies
+# 依存関係を整理
 go mod tidy
 
-# Compile the project
+# ビルド
 go build
 
-# Change setting 
-# File path go-admin/config/settings.yml
+# 設定を変更
+# ファイルパス  go-admin/config/settings.yml
 vi ./config/settings.yml
 
-# 1. Modify the database information in the configuration file
-# Note: The corresponding configuration data under settings.database
-# 2. Confirm the log path
+# 1. 設定ファイル内のデータベース情報を変更
+# 注意: settings.database 配下の設定項目
+# 2. log のパスを確認
 ```
 
-:::tip ⚠️Note that this problem will occur if CGO is not installed in the windows10+ environment;
+⚠️注意 Windows 環境で CGO が未導入の場合、次のエラーが発生します。
 
 ```bash
 E:\go-admin>go build
@@ -171,49 +173,55 @@ D:\Code\go-admin>go build
 cgo: exec gcc: exec: "gcc": executable file not found in %PATH%
 ```
 
-[Solve the cgo problem and enter](https://www.go-admin.pro/guide/faq#cgo-%E7%9A%84%E9%97%AE%E9%A2%98)
+[cgo の問題の解決方法はこちら](https://www.go-admin.pro/zh-CN/guide/faq#cgo-%E7%9A%84%E9%97%AE%E9%A2%98)
 
-:::
 
-#### Initialize the database, and start the service
+#### データベースの初期化とサービス起動
 
 ``` bash
-# The first configuration needs to initialize the database resource information
-# Use under macOS or linux
+# 初回はデータベースのリソース情報を初期化する必要があります
+# macOS または linux の場合
 $ ./go-admin migrate -c config/settings.dev.yml
 
-# ⚠️Note: Use under windows
+# ⚠️注意: windows の場合
 $ go-admin.exe migrate -c config/settings.dev.yml
 
-# Start the project, you can also use the IDE for debugging
-# Use under macOS or linux
+
+# プロジェクトを起動します。IDE からデバッグ実行することもできます
+# macOS または linux の場合
 $ ./go-admin server -c config/settings.yml
 
-# ⚠️Note: Use under windows
+
+# ⚠️注意: windows の場合
 $ go-admin.exe server -c config/settings.yml
 ```
 
-#### Use docker to compile and start
+#### sys_api テーブルへのデータ追加方法
+
+起動時に `-a true` を付けると、不足している API データが自動的に追加されます。
+```bash
+./go-admin server -c config/settings.yml -a true
+```
+
+#### docker でのビルドと起動
 
 ```shell
-# Compile the image
+# イメージをビルド
 docker build -t go-admin .
 
-
-# Start the container, the first go-admin is the container name, and the second go-admin is the image name
-# -v Mapping configuration file Local path: container path
+# コンテナを起動します。1 つ目の go-admin はコンテナ名、2 つ目はイメージ名です
+# -v は設定ファイルのマウント ローカルパス：コンテナ内パス
 docker run --name go-admin -p 8000:8000 -v /config/settings.yml:/config/settings.yml -d go-admin-server
 ```
 
-
-
-#### Generation Document
+#### ドキュメント生成
 
 ```bash
 go generate
 ```
 
-#### Cross compile
+#### クロスコンパイル
+
 ```bash
 # windows
 env GOOS=windows GOARCH=amd64 go build main.go
@@ -223,37 +231,41 @@ env GOOS=windows GOARCH=amd64 go build main.go
 env GOOS=linux GOARCH=amd64 go build main.go
 ```
 
-### UI interactive terminal startup instructions
+### UI 側の起動方法
 
 ```bash
-# Install pnpm if you don't have it
+# pnpm をインストール（未導入の場合）
 npm install -g pnpm
 
-# Installation dependencies
+# 依存関係をインストール
 pnpm install
 
-# Start service
+# 中国本土のネットワークではミラーを指定すると高速化できます
+pnpm install --registry=https://registry.npmmirror.com
+
+# 開発サーバーを起動
 pnpm dev
 ```
 
-## 📨 Interactive
+## 📨 コミュニティ
 
 <table>
-  <tr>
+   <tr>
     <td><img src="https://raw.githubusercontent.com/wenjianzhang/image/master/img/wx.png" width="180px"></td>
     <td><img src="https://doc-image.zhangwj.com/img/qrcode_for_gh_b798dc7db30c_258.jpg" width="180px"></td>
     <td><img src="https://raw.githubusercontent.com/wenjianzhang/image/master/img/qq2.png" width="200px"></td>
     <td><a href="https://space.bilibili.com/565616721">wenjianzhang</a></td>
   </tr>
   <tr>
-    <td>Wechat</td>
-    <td>Wechat公众号🔥🔥🔥</td>
+    <td>微信</td>
+    <td>公众号🔥🔥🔥</td>
     <td><a target="_blank" href="https://shang.qq.com/wpa/qunwpa?idkey=0f2bf59f5f2edec6a4550c364242c0641f870aa328e468c4ee4b7dbfb392627b"><img border="0" src="https://pub.idqqimg.com/wpa/images/group.png" alt="go-admin技术交流乙号" title="go-admin技术交流乙号"></a></td>
-    <td>bilibili🔥🔥🔥</td>
+    <td>哔哩哔哩🔥🔥🔥</td>
   </tr>
 </table>
 
-## 💎 Contributors
+## 💎 コントリビューター
+
 
 <span style="margin: 0 5px;" ><a href="https://github.com/wenjianzhang" ><img src="https://images.weserv.nl/?url=avatars.githubusercontent.com/u/3890175?v=4&h=60&w=60&fit=cover&mask=circle&maxage=7d" /></a></span>
 <span style="margin: 0 5px;" ><a href="https://github.com/G-Akiraka" ><img src="https://images.weserv.nl/?url=avatars.githubusercontent.com/u/45746659?s=64&v=4&w=60&fit=cover&mask=circle&maxage=7d" /></a></span>
@@ -299,39 +311,36 @@ pnpm dev
 " ><img src="https://images.weserv.nl/?url=avatars.githubusercontent.com/u/1410597?s=60&v=4&w=60&fit=cover&mask=circle&maxage=7d" /></a></span>
 <span style="margin: 0 5px;" ><a href="https://github.com/Nicole0724
 " ><img src="https://images.weserv.nl/?url=avatars.githubusercontent.com/u/10487328?s=60&v=4&w=60&fit=cover&mask=circle&maxage=7d" /></a></span>
+## JetBrains のオープンソースライセンス支援
 
-
-
-## JetBrains open source certificate support
-
-The `go-admin` project has always been developed in the GoLand integrated development environment under JetBrains, based on the **free JetBrains Open Source license(s)** genuine free license. I would like to express my gratitude.
+`go-admin` は一貫して JetBrains 社の GoLand 統合開発環境で開発されています。**free JetBrains Open Source license(s)** による正規の無償ライセンス提供に、この場を借りて感謝を申し上げます。
 
 <a href="https://www.jetbrains.com/?from=kubeadm-ha" target="_blank"><img src="https://raw.githubusercontent.com/panjf2000/illustrations/master/jetbrains/jetbrains-variant-4.png" width="250" align="middle"/></a>
 
-
-## 🤝 Thanks
+## 🤝 謝辞
 
 1. [ant-design](https://github.com/ant-design/ant-design)
 2. [ant-design-pro](https://github.com/ant-design/ant-design-pro)
 2. [arco-design](https://github.com/arco-design/arco-design)
 2. [arco-design-pro](https://github.com/arco-design/arco-design-pro)
-2. [gin](https://github.com/gin-gonic/gin)
-2. [casbin](https://github.com/casbin/casbin)
-2. [spf13/viper](https://github.com/spf13/viper)
-2. [gorm](https://github.com/go-gorm/gorm)
-2. [gin-swagger](https://github.com/swaggo/gin-swagger)
-2. [golang-jwt](https://github.com/golang-jwt/jwt)
-2. [vue-element-admin](https://github.com/PanJiaChen/vue-element-admin)
-2. [ruoyi-vue](https://gitee.com/y_project/RuoYi-Vue)
-2. [form-generator](https://github.com/JakHuang/form-generator)
+4. [gin](https://github.com/gin-gonic/gin)
+5. [casbin](https://github.com/casbin/casbin)
+6. [spf13/viper](https://github.com/spf13/viper)
+7. [gorm](https://github.com/go-gorm/gorm)
+8. [gin-swagger](https://github.com/swaggo/gin-swagger)
+9. [golang-jwt](https://github.com/golang-jwt/jwt)
+10. [vue-element-admin](https://github.com/PanJiaChen/vue-element-admin)
+11. [ruoyi-vue](https://gitee.com/y_project/RuoYi-Vue)
+12. [form-generator](https://github.com/JakHuang/form-generator)
 
-## 🤟 Sponsor Us
+## 🤟 支援
 
-> If you think this project helped you, you can buy a glass of juice for the author to show encouragement :tropical_drink:
+> このプロジェクトがお役に立ちましたら、作者にジュースを一杯おごる形で応援いただけます :tropical_drink:
 
 <img class="no-margin" src="https://raw.githubusercontent.com/wenjianzhang/image/master/img/pay.png"  height="200px" >
 
-## 🤝 Link
+## 🤝 関連リンク
+
 - [mss-boot-io](https://docs.mss-boot-io.top/)
 
 ## 🔑 License

--- a/README.md
+++ b/README.md
@@ -4,15 +4,15 @@
 <img align="right" width="320" src="https://raw.githubusercontent.com/wenjianzhang/image/203c5930b9ed08d5cf2fcb4516b85e412f8e0e60/img/go-admin.svg">
 
 
-[![Build Status](https://github.com/wenjianzhang/go-admin/workflows/build/badge.svg)](https://github.com/go-admin-team/go-admin)
+[![Build Status](https://github.com/go-admin-team/go-admin/actions/workflows/go.yml/badge.svg?branch=master)](https://github.com/go-admin-team/go-admin)
 [![Release](https://img.shields.io/github/release/go-admin-team/go-admin.svg?style=flat-square)](https://github.com/go-admin-team/go-admin/releases)
-[![License](https://img.shields.io/github/license/mashape/apistatus.svg)](https://github.com/go-admin-team/go-admin)
+[![License](https://img.shields.io/github/license/go-admin-team/go-admin.svg)](https://github.com/go-admin-team/go-admin)
 
 English | [简体中文](https://github.com/go-admin-team/go-admin/blob/master/README.Zh-cn.md)
 
-The front-end and back-end separation authority management system based on Gin + Vue + Element UI OR Arco Design is extremely simple to initialize the system. You only need to modify the database connection in the configuration file. The system supports multi-instruction operations. Migration instructions can make it easier to initialize database information. Service instructions It's easy to start the api service.
+The front-end and back-end separation authority management system based on Gin + Vue + Element UI OR Arco Design OR Ant Design is extremely simple to initialize the system. You only need to modify the database connection in the configuration file. The system supports multi-instruction operations. Migration instructions can make it easier to initialize database information. Service instructions It's easy to start the api service.
 
-[documentation](https://www.go-admin.dev)
+[documentation](https://www.go-admin.pro)
 
 [Front-end project](https://github.com/go-admin-team/go-admin-ui)
 
@@ -76,9 +76,9 @@ At the same time, a series of tutorials including videos and documents are provi
 
 ### Easily implement go-admin to write the first application-documentation tutorial
 
-[Step 1 - basic content introduction](https://doc.go-admin.dev/guide/intro/tutorial01.html)
+[Step 1 - basic content introduction](https://www.go-admin.pro/guide/intro/tutorial01.html)
 
-[Step 2 - Practical application - writing database operations](https://doc.go-admin.dev/guide/intro/tutorial02.html)
+[Step 2 - Practical application - writing database operations](https://www.go-admin.pro/guide/intro/tutorial02.html)
 
 ### Teach you from getting started to giving up-video tutorial
 
@@ -171,7 +171,7 @@ D:\Code\go-admin>go build
 cgo: exec gcc: exec: "gcc": executable file not found in %PATH%
 ```
 
-[Solve the cgo problem and enter](https://doc.go-admin.dev/guide/faq#cgo-%E7%9A%84%E9%97%AE%E9%A2%98)
+[Solve the cgo problem and enter](https://www.go-admin.pro/guide/faq#cgo-%E7%9A%84%E9%97%AE%E9%A2%98)
 
 :::
 
@@ -318,7 +318,7 @@ The `go-admin` project has always been developed in the GoLand integrated develo
 2. [gin](https://github.com/gin-gonic/gin)
 2. [casbin](https://github.com/casbin/casbin)
 2. [spf13/viper](https://github.com/spf13/viper)
-2. [gorm](https://github.com/jinzhu/gorm)
+2. [gorm](https://github.com/go-gorm/gorm)
 2. [gin-swagger](https://github.com/swaggo/gin-swagger)
 2. [golang-jwt](https://github.com/golang-jwt/jwt)
 2. [vue-element-admin](https://github.com/PanJiaChen/vue-element-admin)

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -1,161 +1,163 @@
-
 # go-admin
 
-<img align="right" width="320" src="https://raw.githubusercontent.com/wenjianzhang/image/203c5930b9ed08d5cf2fcb4516b85e412f8e0e60/img/go-admin.svg">
+  <img align="right" width="320" src="https://doc-image.zhangwj.com/img/go-admin.svg">
 
 
 [![Build Status](https://github.com/go-admin-team/go-admin/actions/workflows/go.yml/badge.svg?branch=master)](https://github.com/go-admin-team/go-admin)
 [![Release](https://img.shields.io/github/release/go-admin-team/go-admin.svg?style=flat-square)](https://github.com/go-admin-team/go-admin/releases)
 [![License](https://img.shields.io/github/license/go-admin-team/go-admin.svg)](https://github.com/go-admin-team/go-admin)
 
-English | [简体中文](https://github.com/go-admin-team/go-admin/blob/master/README.Zh-cn.md) | [繁體中文](https://github.com/go-admin-team/go-admin/blob/master/README.zh-TW.md) | [日本語](https://github.com/go-admin-team/go-admin/blob/master/README.ja-JP.md)
+[English](https://github.com/go-admin-team/go-admin/blob/master/README.md) | [简体中文](https://github.com/go-admin-team/go-admin/blob/master/README.Zh-cn.md) | 繁體中文 | [日本語](https://github.com/go-admin-team/go-admin/blob/master/README.ja-JP.md)
 
-The front-end and back-end separation authority management system based on Gin + Vue + Element UI OR Arco Design OR Ant Design is extremely simple to initialize the system. You only need to modify the database connection in the configuration file. The system supports multi-instruction operations. Migration instructions can make it easier to initialize database information. Service instructions It's easy to start the api service.
+基於 Gin + Vue + Element UI OR Arco Design OR Ant Design 的前後端分離權限管理系統。系統初始化極為簡單，只需在設定檔中修改資料庫連線資訊即可。系統支援多指令操作：遷移指令讓資料庫初始化變得更簡單，服務指令則能輕鬆啟動 API 服務。
 
-[documentation](https://www.go-admin.pro)
+[線上文件](https://www.go-admin.pro)
 
-[Front-end project](https://github.com/go-admin-team/go-admin-ui)
+[前端專案](https://github.com/go-admin-team/go-admin-ui)
 
-[Video tutorial](https://space.bilibili.com/565616721/channel/detail?cid=125737)
+[影片教學](https://space.bilibili.com/565616721/channel/detail?cid=125737)
 
-## 🎬 Online Demo
+## 🎬 線上體驗
 
-Element Plus vue3 demo：[https://vue.go-admin.pro](https://vue.go-admin.pro/#/login)
-> Account / Password: admin / 123456
+Element Plus vue3 體驗：[https://vue.go-admin.pro](https://vue.go-admin.pro/#/login)
+> ⚠️⚠️⚠️ 帳號 / 密碼： admin / 123456
 
-antd demo (go-admin-pro)：[https://antd.go-admin.pro](https://antd.go-admin.pro/)
-> Account / Password: admin / 123456
-> 
-## ✨ Feature
+antd 體驗（go-admin-pro）：[https://antd.go-admin.pro](https://antd.go-admin.pro/)
+> ⚠️⚠️⚠️ 帳號 / 密碼： admin / 123456
 
-- Follow RESTful API design specifications
+## ✨ 特性
 
-- Based on the GIN WEB API framework, it provides rich middleware support (user authentication, cross-domain, access log, tracking ID, etc.)
+- 遵循 RESTful API 設計規範
 
-- RBAC access control model based on Casbin
+- 基於 GIN WEB API 框架，提供豐富的中介軟體支援（使用者認證、跨域、存取日誌、追蹤 ID 等）
 
-- JWT authentication
+- 基於 Casbin 的 RBAC 存取控制模型
 
-- Support Swagger documents (based on swaggo)
+- JWT 認證
 
-- Database storage based on GORM, which can expand multiple types of databases
+- 支援 Swagger 文件（基於 swaggo）
 
-- Simple model mapping of configuration files to quickly get the desired configuration
+- 基於 GORM 的資料庫儲存，可擴充多種類型資料庫
 
-- Code generation tool
+- 設定檔簡單的模型映射，快速取得所需設定
 
-- Form builder
+- 程式碼產生工具
 
-- Multi-command mode
+- 表單建構工具
 
-- TODO: unit test
+- 多指令模式
 
+- 多租戶的支援
 
-## 🎁 Internal
+- TODO: 單元測試
 
-1. User management: The user is the system operator, this function mainly completes the system user configuration.
-2. Department management: configure the system organization (company, department, group), and display the tree structure to support data permissions.
-3. Position management: configure the positions of system users.
-4. Menu management: configure the system menu, operation authority, button authority identification, interface authority, etc.
-5. Role management: Role menu permission assignment and role setting are divided into data scope permissions by organization.
-6. Dictionary management: Maintain some relatively fixed data frequently used in the system.
-7. Parameter management: dynamically configure common parameters for the system.
-8. Operation log: system normal operation log record and query; system abnormal information log record and query.
-9. Login log: The system login log record query contains login exceptions.
-1. Interface documentation: Automatically generate related api interface documents according to the business code.
-1. Code generation: According to the data table structure, generate the corresponding addition, deletion, modification, and check corresponding business, and the whole process of visual operation, so that the basic business can be implemented with zero code.
-1. Form construction: Customize the page style, drag and drop to realize the page layout.
-1. Service monitoring: View the basic information of some servers.
-1. Content management: demo function, including classification management and content management. You can refer to the easy to use quick start.
+## 🎁 內建
 
-## Ready to work
+1. 多租戶：系統預設支援多租戶，按資料庫分離，一個資料庫一個租戶。
+1. 使用者管理：使用者是系統操作者，該功能主要完成系統使用者設定。
+2. 部門管理：設定系統組織架構（公司、部門、小組），以樹狀結構呈現並支援資料權限。
+3. 職位管理：設定系統使用者所擔任的職務。
+4. 選單管理：設定系統選單、操作權限、按鈕權限標識、介面權限等。
+5. 角色管理：角色選單權限分配、設定角色按機構進行資料範圍權限劃分。
+6. 字典管理：對系統中經常使用且較為固定的資料進行維護。
+7. 參數管理：對系統動態設定常用參數。
+8. 操作日誌：系統正常操作的日誌記錄與查詢；系統異常資訊的日誌記錄與查詢。
+9. 登入日誌：系統登入日誌記錄查詢，包含登入異常。
+1. 介面文件：根據業務程式碼自動產生相關的 API 介面文件。
+1. 程式碼產生：根據資料表結構產生對應的增刪改查業務，全程視覺化操作，讓基本業務可以零程式碼實現。
+1. 表單建構：自訂頁面樣式，拖拉放實現頁面佈局。
+1. 服務監控：檢視伺服器的基本資訊。
+1. 內容管理：demo 功能，下設分類管理、內容管理，可參考使用以快速入門。
+1. 排程任務：自動化任務，目前支援介面呼叫與函式呼叫。
 
-You need to install locally [go] [gin] [node](http://nodejs.org/) 和 [git](https://git-scm.com/)
+## 準備工作
 
-At the same time, a series of tutorials including videos and documents are provided. How to complete the downloading to the proficient use, it is strongly recommended that you read these tutorials before you practice this project! ! !
+你需要在本機安裝 [go] [gin] [node](http://nodejs.org/) 和 [git](https://git-scm.com/)
 
-### Easily implement go-admin to write the first application-documentation tutorial
+同時配套了系列教學（含影片與文件），說明如何從下載到熟練使用。強烈建議先看完這些教學再來實作本專案！！！
 
-[Step 1 - basic content introduction](https://www.go-admin.pro/guide/intro/tutorial01.html)
+### 輕鬆用 go-admin 寫出第一個應用 - 文件教學
 
-[Step 2 - Practical application - writing database operations](https://www.go-admin.pro/guide/intro/tutorial02.html)
+[步驟一 - 基礎內容介紹](https://www.go-admin.pro/guide/intro/tutorial01.html)
 
-### Teach you from getting started to giving up-video tutorial
+[步驟二 - 實際應用 - 撰寫增刪改查](https://www.go-admin.pro/guide/intro/tutorial02.html)
 
-[How to start go-admin](https://www.bilibili.com/video/BV1z5411x7JG)
+### 手把手教你從入門到放棄 - 影片教學
 
-[Easily implement business using build tools](https://www.bilibili.com/video/BV1Dg4y1i79D)
+[如何啟動 go-admin](https://www.bilibili.com/video/BV1z5411x7JG)
 
-[v1.1.0 version code generation tool-free your hands](https://www.bilibili.com/video/BV1N54y1i71P) [Advanced]
+[使用產生工具輕鬆實現業務](https://www.bilibili.com/video/BV1Dg4y1i79D)
 
-[Explanation of multi-command startup mode and IDE configuration](https://www.bilibili.com/video/BV1Fg4y1q7ph)
+[v1.1.0 版本程式碼產生工具 - 釋放雙手](https://www.bilibili.com/video/BV1N54y1i71P) [進階]
 
-[Configuration instructions for go-admin menu](https://www.bilibili.com/video/BV1Wp4y1D715) [Must see]
+[多指令啟動方式講解以及 IDE 設定](https://www.bilibili.com/video/BV1Fg4y1q7ph)
 
-[How to configure menu information and interface information](https://www.bilibili.com/video/BV1zv411B7nG) [Must see]
+[go-admin 選單的設定說明](https://www.bilibili.com/video/BV1Wp4y1D715) [必看]
 
-[go-admin permission configuration instructions](https://www.bilibili.com/video/BV1rt4y197d3) [Must see]
+[如何設定選單資訊以及介面資訊](https://www.bilibili.com/video/BV1zv411B7nG) [必看]
 
-[Instructions for use of go-admin data permissions](https://www.bilibili.com/video/BV1LK4y1s71e) [Must see]
+[go-admin 權限設定使用說明](https://www.bilibili.com/video/BV1rt4y197d3) [必看]
 
-**If you have any questions, please read the above-mentioned usage documents and articles first. If you are not satisfied, welcome to issue and pr. Video tutorials and documents are being updated continuously.**
+[go-admin 資料權限使用說明](https://www.bilibili.com/video/BV1LK4y1s71e) [必看]
 
-## 📦 Local development
+**如有問題請先參閱上述文件與文章，若仍無法解決，歡迎提出 issue 與 pr。影片教學與文件持續更新中**
 
-### Environmental requirements
+## 📦 本機開發
+
+### 環境需求
 
 go 1.26.5
 
-nodejs: v22+ (v24 LTS recommended)
+node 版本: v22+（建議 v24 LTS）
 
-package manager: pnpm v9+ (the UI project uses pnpm)
+套件管理器: pnpm v9+（UI 專案使用 pnpm）
 
-### Development directory creation
+### 建立開發目錄
 
 ```bash
 
-# Create a development directory
+# 建立開發目錄
 mkdir goadmin
 cd goadmin
 ```
 
-### Get the code
+### 取得程式碼
 
-> Important note: the two projects must be placed in the same folder;
+> 重點注意：兩個專案必須放在同一資料夾下；
 
 ```bash
-# Get backend code
+# 取得後端程式碼
 git clone https://github.com/go-admin-team/go-admin.git
 
-# Get the front-end code
+# 取得前端程式碼
 git clone https://github.com/go-admin-team/go-admin-ui.git
 
 ```
 
-### Startup instructions
+### 啟動說明
 
-#### Server startup instructions
+#### 伺服器端啟動說明
 
 ```bash
-# Enter the go-admin backend project
+# 進入 go-admin 後端專案
 cd ./go-admin
 
-# Update dependencies
+# 更新整理相依套件
 go mod tidy
 
-# Compile the project
+# 編譯專案
 go build
 
-# Change setting 
-# File path go-admin/config/settings.yml
+# 修改設定
+# 檔案路徑  go-admin/config/settings.yml
 vi ./config/settings.yml
 
-# 1. Modify the database information in the configuration file
-# Note: The corresponding configuration data under settings.database
-# 2. Confirm the log path
+# 1. 在設定檔中修改資料庫資訊
+# 注意: settings.database 下對應的設定資料
+# 2. 確認 log 路徑
 ```
 
-:::tip ⚠️Note that this problem will occur if CGO is not installed in the windows10+ environment;
+⚠️注意 在 Windows 環境若未安裝 CGO，會出現這個問題；
 
 ```bash
 E:\go-admin>go build
@@ -171,49 +173,55 @@ D:\Code\go-admin>go build
 cgo: exec gcc: exec: "gcc": executable file not found in %PATH%
 ```
 
-[Solve the cgo problem and enter](https://www.go-admin.pro/guide/faq#cgo-%E7%9A%84%E9%97%AE%E9%A2%98)
+[解決 cgo 問題請進入](https://www.go-admin.pro/zh-CN/guide/faq#cgo-%E7%9A%84%E9%97%AE%E9%A2%98)
 
-:::
 
-#### Initialize the database, and start the service
+#### 初始化資料庫，以及服務啟動
 
 ``` bash
-# The first configuration needs to initialize the database resource information
-# Use under macOS or linux
+# 首次設定需要初始化資料庫資源資訊
+# macOS or linux 下使用
 $ ./go-admin migrate -c config/settings.dev.yml
 
-# ⚠️Note: Use under windows
+# ⚠️注意:windows 下使用
 $ go-admin.exe migrate -c config/settings.dev.yml
 
-# Start the project, you can also use the IDE for debugging
-# Use under macOS or linux
+
+# 啟動專案，也可以用 IDE 進行除錯
+# macOS or linux 下使用
 $ ./go-admin server -c config/settings.yml
 
-# ⚠️Note: Use under windows
+
+# ⚠️注意:windows 下使用
 $ go-admin.exe server -c config/settings.yml
 ```
 
-#### Use docker to compile and start
+#### sys_api 表的資料如何新增
+
+在專案啟動時，使用 `-a true` 系統會自動新增缺少的介面資料
+```bash
+./go-admin server -c config/settings.yml -a true
+```
+
+#### 使用 docker 編譯啟動
 
 ```shell
-# Compile the image
+# 編譯映像檔
 docker build -t go-admin .
 
-
-# Start the container, the first go-admin is the container name, and the second go-admin is the image name
-# -v Mapping configuration file Local path: container path
+# 啟動容器，第一個 go-admin 是容器名稱，第二個 go-admin 是映像檔名稱
+# -v 映射設定檔 本機路徑：容器路徑
 docker run --name go-admin -p 8000:8000 -v /config/settings.yml:/config/settings.yml -d go-admin-server
 ```
 
-
-
-#### Generation Document
+#### 文件產生
 
 ```bash
 go generate
 ```
 
-#### Cross compile
+#### 交叉編譯
+
 ```bash
 # windows
 env GOOS=windows GOARCH=amd64 go build main.go
@@ -223,37 +231,41 @@ env GOOS=windows GOARCH=amd64 go build main.go
 env GOOS=linux GOARCH=amd64 go build main.go
 ```
 
-### UI interactive terminal startup instructions
+### UI 互動端啟動說明
 
 ```bash
-# Install pnpm if you don't have it
+# 安裝 pnpm（若未安裝）
 npm install -g pnpm
 
-# Installation dependencies
+# 安裝相依套件
 pnpm install
 
-# Start service
+# 中國大陸網路可指定鏡像來源加速
+pnpm install --registry=https://registry.npmmirror.com
+
+# 啟動服務
 pnpm dev
 ```
 
-## 📨 Interactive
+## 📨 互動
 
 <table>
-  <tr>
+   <tr>
     <td><img src="https://raw.githubusercontent.com/wenjianzhang/image/master/img/wx.png" width="180px"></td>
     <td><img src="https://doc-image.zhangwj.com/img/qrcode_for_gh_b798dc7db30c_258.jpg" width="180px"></td>
     <td><img src="https://raw.githubusercontent.com/wenjianzhang/image/master/img/qq2.png" width="200px"></td>
     <td><a href="https://space.bilibili.com/565616721">wenjianzhang</a></td>
   </tr>
   <tr>
-    <td>Wechat</td>
-    <td>Wechat公众号🔥🔥🔥</td>
+    <td>微信</td>
+    <td>公众号🔥🔥🔥</td>
     <td><a target="_blank" href="https://shang.qq.com/wpa/qunwpa?idkey=0f2bf59f5f2edec6a4550c364242c0641f870aa328e468c4ee4b7dbfb392627b"><img border="0" src="https://pub.idqqimg.com/wpa/images/group.png" alt="go-admin技术交流乙号" title="go-admin技术交流乙号"></a></td>
-    <td>bilibili🔥🔥🔥</td>
+    <td>哔哩哔哩🔥🔥🔥</td>
   </tr>
 </table>
 
-## 💎 Contributors
+## 💎 貢獻者
+
 
 <span style="margin: 0 5px;" ><a href="https://github.com/wenjianzhang" ><img src="https://images.weserv.nl/?url=avatars.githubusercontent.com/u/3890175?v=4&h=60&w=60&fit=cover&mask=circle&maxage=7d" /></a></span>
 <span style="margin: 0 5px;" ><a href="https://github.com/G-Akiraka" ><img src="https://images.weserv.nl/?url=avatars.githubusercontent.com/u/45746659?s=64&v=4&w=60&fit=cover&mask=circle&maxage=7d" /></a></span>
@@ -299,39 +311,36 @@ pnpm dev
 " ><img src="https://images.weserv.nl/?url=avatars.githubusercontent.com/u/1410597?s=60&v=4&w=60&fit=cover&mask=circle&maxage=7d" /></a></span>
 <span style="margin: 0 5px;" ><a href="https://github.com/Nicole0724
 " ><img src="https://images.weserv.nl/?url=avatars.githubusercontent.com/u/10487328?s=60&v=4&w=60&fit=cover&mask=circle&maxage=7d" /></a></span>
+## JetBrains 開源證書支援
 
-
-
-## JetBrains open source certificate support
-
-The `go-admin` project has always been developed in the GoLand integrated development environment under JetBrains, based on the **free JetBrains Open Source license(s)** genuine free license. I would like to express my gratitude.
+`go-admin` 專案一直以來都是在 JetBrains 公司旗下的 GoLand 整合開發環境中進行開發，基於 **free JetBrains Open Source license(s)** 正版免費授權，在此表達我的謝意。
 
 <a href="https://www.jetbrains.com/?from=kubeadm-ha" target="_blank"><img src="https://raw.githubusercontent.com/panjf2000/illustrations/master/jetbrains/jetbrains-variant-4.png" width="250" align="middle"/></a>
 
-
-## 🤝 Thanks
+## 🤝 特別感謝
 
 1. [ant-design](https://github.com/ant-design/ant-design)
 2. [ant-design-pro](https://github.com/ant-design/ant-design-pro)
 2. [arco-design](https://github.com/arco-design/arco-design)
 2. [arco-design-pro](https://github.com/arco-design/arco-design-pro)
-2. [gin](https://github.com/gin-gonic/gin)
-2. [casbin](https://github.com/casbin/casbin)
-2. [spf13/viper](https://github.com/spf13/viper)
-2. [gorm](https://github.com/go-gorm/gorm)
-2. [gin-swagger](https://github.com/swaggo/gin-swagger)
-2. [golang-jwt](https://github.com/golang-jwt/jwt)
-2. [vue-element-admin](https://github.com/PanJiaChen/vue-element-admin)
-2. [ruoyi-vue](https://gitee.com/y_project/RuoYi-Vue)
-2. [form-generator](https://github.com/JakHuang/form-generator)
+4. [gin](https://github.com/gin-gonic/gin)
+5. [casbin](https://github.com/casbin/casbin)
+6. [spf13/viper](https://github.com/spf13/viper)
+7. [gorm](https://github.com/go-gorm/gorm)
+8. [gin-swagger](https://github.com/swaggo/gin-swagger)
+9. [golang-jwt](https://github.com/golang-jwt/jwt)
+10. [vue-element-admin](https://github.com/PanJiaChen/vue-element-admin)
+11. [ruoyi-vue](https://gitee.com/y_project/RuoYi-Vue)
+12. [form-generator](https://github.com/JakHuang/form-generator)
 
-## 🤟 Sponsor Us
+## 🤟 贊助
 
-> If you think this project helped you, you can buy a glass of juice for the author to show encouragement :tropical_drink:
+> 如果你覺得這個專案幫助到了你，可以幫作者買一杯果汁表示鼓勵 :tropical_drink:
 
 <img class="no-margin" src="https://raw.githubusercontent.com/wenjianzhang/image/master/img/pay.png"  height="200px" >
 
-## 🤝 Link
+## 🤝 連結
+
 - [mss-boot-io](https://docs.mss-boot-io.top/)
 
 ## 🔑 License


### PR DESCRIPTION
The build badge has been rendering **`build - failing`** on both READMEs while CI is green.

It referenced the workflow under the old personal repository path, where the status has been stale for years — so the first thing anyone saw on opening this project was a failed build, with nothing to suggest it was wrong.

| | renders |
|---|---|
| `wenjianzhang/go-admin/workflows/build/badge.svg` | `build - failing` |
| `go-admin-team/go-admin/actions/workflows/go.yml/badge.svg?branch=master` | `build - passing` |

It now names the workflow file explicitly and pins the branch, so it reports `master` rather than whatever happens to be the default branch later.

It points at **`go.yml`**, which is what the old badge referenced by workflow name (`build`, lowercase — `build.yml` is `Build`). That is also the right one to show: `build.yml` deploys the demo site, so a server-side problem there would turn the badge red while the code is fine.

## Other links that pointed elsewhere

- The **licence badge** read from `mashape/apistatus` — the example repository from shields.io's own documentation. It happened to show MIT, the same licence this project uses, which is why nobody noticed, but it reports someone else's licence.
- **Documentation links were spread across three hosts.** `doc.go-admin.dev` 301s to `www.go-admin.pro`; `www.go-admin.dev` serves byte-identical content; and only the Chinese README linked the canonical host at all — the English one did not link it anywhere. All now point at `www.go-admin.pro` directly, rather than relying on a redirect outliving the domain that issues it.
- The **gorm link** pointed at the archived v1 repository (`jinzhu/gorm`) while the project builds on gorm.io v2.
- The **English introduction** listed two UI kits where the Chinese listed three, with an Ant Design demo linked three lines below it.

## Traditional Chinese and Japanese

Same structure as the existing two — same sections, same code blocks, same contributor list — so a reader in any of the four sees the same document. The contributor avatars and the thanks list are extracted from the existing file rather than retyped.

The Traditional Chinese is a translation, not a character conversion: the terminology differs (設定檔 / 資料庫 / 選單 / 程式碼產生 / 排程任務 / 相依套件), and a converted file reads as machine output to anyone who actually uses it.

Language navigation is unified across all four in the same commit that adds the files, since a link to a file that does not exist yet would be worse than no link.

## Two things left alone deliberately

- **File naming.** The existing Simplified Chinese file is `README.Zh-cn.md`; the new ones use the conventional `README.zh-TW.md` / `README.ja-JP.md`. Renaming the existing file would 404 every external link to it — the documentation site and older issues may well reference it.
- **Copyright line.** The READMEs end with `Copyright (c) 2026 wenjianzhang` while `LICENSE.md` says `Copyright (c) 2026 go-admin-team`. They disagree, but that is an ownership statement rather than a typo, so it is not mine to change.
