### PR TITLE
docs📝: drop VitePress container syntax GitHub cannot render

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ vi ./config/settings.yml
 # 2. Confirm the log path
 ```
 
-:::tip ⚠️Note that this problem will occur if CGO is not installed in the windows10+ environment;
+⚠️ Note that this problem will occur if CGO is not installed in the windows10+ environment;
 
 ```bash
 E:\go-admin>go build
@@ -172,8 +172,6 @@ cgo: exec gcc: exec: "gcc": executable file not found in %PATH%
 ```
 
 [Solve the cgo problem and enter](https://www.go-admin.pro/guide/faq#cgo-%E7%9A%84%E9%97%AE%E9%A2%98)
-
-:::
 
 #### Initialize the database, and start the service
 


### PR DESCRIPTION
`:::tip` and its closing `:::` are VitePress custom containers. GitHub has no such syntax, so both markers render as literal text — a paragraph starting with `:::tip`, and a stray `:::` sitting alone above the next heading.

Most likely carried over from the documentation site, which is VitePress-driven and does understand them.

The Chinese README already carries the same warning as a plain paragraph, which GitHub renders correctly, so the English one now matches it.

```diff
-:::tip ⚠️Note that this problem will occur if CGO is not installed in the windows10+ environment;
+⚠️ Note that this problem will occur if CGO is not installed in the windows10+ environment;

 [Solve the cgo problem and enter](...)
-
-:::
```

Verified through GitHub's own markdown API: the literal marker no longer appears in the rendered output, and the warning survives as ordinary text.

Only `README.md` was affected — the other three never had it.

## Also scanned, and left alone

The other non-GitHub constructs worth checking are absent from all four files: no frontmatter, no Vue interpolation, no Liquid tags, no `[[toc]]`, no `<script>`.

The contributor avatars carry `style="margin: 0 5px;"` on 38 `<span>` elements, which GitHub strips. That costs the spacing between avatars but nothing else — the images render — so it is a cosmetic loss rather than a rendering fault, and cleaning it would mean touching 38 elements in each of four files.
