### PR TITLE
ci🔧: skip the deploy workflow for documentation-only changes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,10 +1,27 @@
 name: Build
 
+# Documentation-only changes skip this workflow entirely.
+#
+# A push to master here does not just build - it pushes an image, runs the
+# migrations and restarts the demo container, so the site takes a short outage.
+# Paying that for a README edit is waste at best; at worst a deploy fails for a
+# reason unrelated to anything in the change. Code coverage is unaffected,
+# because go.yml still builds every push and pull request.
 on:
   push:
     branches: [ master ]
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+      - 'LICENSE*'
+      - '.github/ISSUE_TEMPLATE/**'
   pull_request:
     branches: [ master ]
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+      - 'LICENSE*'
+      - '.github/ISSUE_TEMPLATE/**'
 
 # One deploy at a time. Two merges seconds apart raced here: both runs did
 # docker rm -f then docker run, the second removed the container the first had


### PR DESCRIPTION
Merging #882 and #883 — markdown only, both of them — ran the full deploy each time: build, push image, run migrations, restart the demo container. The site took an outage for a README edit.

Beyond the waste, a deploy can fail for reasons that have nothing to do with the change that triggered it: a container that will not come up, a database briefly unreachable. A README edit should not be able to turn the demo red.

`paths-ignore` covers `**.md`, `docs/**`, `LICENSE*` and the issue templates.

Only `build.yml` is filtered. `go.yml` still runs on every push and pull request, so no change loses its compile check, and the build badge keeps reporting the same workflow it reports today.
