### PR TITLE
Run the test suite in CI

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -28,6 +28,13 @@ jobs:
 
     - name: Get dependencies
       run: go mod tidy
+
+    # go build does not compile _test.go, so building alone never ran a single
+    # test. This is the only workflow that fires on every push and pull request,
+    # which makes it the one place a test gate belongs.
+    - name: Test
+      run: make test
+
     - name: Build
       run: make build
 

--- a/Makefile
+++ b/Makefile
@@ -37,9 +37,13 @@ stop:
 	#@echo "go-admin stop success"
 
 
-#.PHONY: test
-#test:
-#	go test -v ./... -cover
+# -race is worth the extra minute here: common/actions reuses model instances
+# across concurrent requests, so a Generate() that returns in place instead of
+# a copy leaks data between them - and that is invisible to a single-threaded
+# test run.
+.PHONY: test
+test:
+	go test -race -cover ./...
 
 #.PHONY: docker
 #docker:


### PR DESCRIPTION
## What

`go.yml` now runs `make test` on every push and pull request, and the Makefile's `test` target is enabled.

## Why

The repository has **19 test files and nothing was running any of them**:

| | |
|---|---|
| `go.yml` | `go mod tidy` + `make build` |
| `build.yml` | `go build` |
| `make build` | `go build ...` — does not compile `_test.go` |
| Makefile `test` target | commented out |
| pre-commit hook | none |

So every test in the tree only ran when a developer remembered to type `go test ./...`. That includes `TestEveryRuntimeSoftDeleteTableIsConverted` and the guard added in #887 — checks that exist specifically to catch breakage that reports no error on its own, and that were themselves never executed.

A green build said nothing about the tests. It only meant the code compiled.

## Choices

**`go.yml`, not `build.yml`.** `build.yml` skips documentation-only changes and, on master, pushes an image and restarts the demo container. A gate that should never be skipped does not belong behind a path filter. `go.yml` fires on every push and pull request, which is what a gate needs.

**`-race`.** `common/actions` reuses model instances across concurrent requests, so a `Generate()` that returns in place rather than a copy leaks data between them — `AGENTS.md` calls this out as the mistake that keeps happening, and a single-threaded run cannot see it. The suite passes under `-race` and the whole run takes about a minute.

## Verification

- `go test ./...` passes under `CGO_ENABLED=0`, matching the build environment
- `go test -race ./...` passes; 14 packages, roughly 70s
- Added a deliberately failing test and confirmed `make test` exits non-zero, then removed it and confirmed it exits zero — the step gates rather than merely reporting
