### PR TITLE
Describe the rules rather than who follows them

### DIFF
--- a/cmd/api/server_test.go
+++ b/cmd/api/server_test.go
@@ -55,10 +55,10 @@ func TestRunStartupHooksRunsBothRegistriesInOrder(t *testing.T) {
 
 // Acceptance 17: a before callback registered through core actually runs.
 //
-// It did not, ever, in the open-source edition: core stored the callbacks and
-// nothing executed them, so SetBefore was accepted and silently did nothing.
-// go-admin-pro had its own loop, which is why the gap survived - the same core
-// API behaved differently in the two downstreams.
+// It did not, ever: core stored the callbacks and nothing executed them, so
+// SetBefore was accepted and silently did nothing. The gap survived because
+// core offered the registry without ever running it, leaving each consumer to
+// write - or forget - its own loop.
 func TestBeforeCallbacksRun(t *testing.T) {
 	freshRuntime(t)
 

--- a/common/middleware/handler/auth.go
+++ b/common/middleware/handler/auth.go
@@ -181,8 +181,9 @@ func LogOut(c *gin.Context) {
 // therefore removes five zero values nobody read, and with them the last
 // import of app/admin from a contract package.
 //
-// go-admin-pro has its own copy of this file and does read those keys; this
-// change must not be carried over there verbatim.
+// Anything maintaining its own copy of this file must check its own consumers
+// before taking this change: a codebase that does read those keys off the
+// context needs Authorizator to keep setting them.
 func Authorizator(data interface{}, c *gin.Context) bool {
 	_, ok := data.(map[string]interface{})
 	return ok

--- a/docs/contract.md
+++ b/docs/contract.md
@@ -153,7 +153,8 @@ go-admin migrate --app crm -c config/settings.yml       # 只跑 crm 的迁移
 
 `init()` 是最省事的位置：Go 规范保证包级变量初始化与 `init()` 在 `main()` 之前
 **单 goroutine 顺序执行**，注册期天然没有并发写。但它不是唯一合法位置——
-只要在启动钩子之前就行（go-admin-pro 就在 `run()` 里注册）。
+在 `run()` 之类早于启动钩子的地方注册同样成立。这条规则约束的是**顺序**，
+不是你写在哪个函数里。
 
 `sdk.Runtime.SetAppRouters` 的准确语义以 core 为准：
 


### PR DESCRIPTION
The warning on `Authorizator` was addressed to one particular consumer. It applies to anyone keeping a copy of that file, and reads better said that way: check what reads those context keys before taking the change.

Same for the registration-timing note in `docs/contract.md` and the comment on the before-callback test — the rule is the point, not who happens to follow it.

No behaviour change; the wording is the whole diff.