### PR TITLE
refactor🎨: 契约包改为 core 的薄壳

### DIFF
--- a/common/actions/crud_shim_test.go
+++ b/common/actions/crud_shim_test.go
@@ -1,0 +1,122 @@
+package actions_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/glebarez/sqlite"
+	"gorm.io/gorm"
+	gormlogger "gorm.io/gorm/logger"
+
+	"github.com/go-admin-team/go-admin-core/v2/sdk/config"
+
+	"go-admin/common/actions"
+	"go-admin/common/dto"
+	"go-admin/common/models"
+)
+
+// capturingLogger records every SQL statement GORM actually executes, so a
+// test can inspect it the way inspecting a *gorm.DB's own Statement cannot:
+// IndexAction builds and executes its query in one unbroken chain
+// (db.Model(...).Scopes(...).Find(...)...Count(...)) and never hands the
+// built statement back to its caller.
+type capturingLogger struct {
+	gormlogger.Interface
+	mu    sync.Mutex
+	stmts []string
+}
+
+func (l *capturingLogger) Trace(ctx context.Context, begin time.Time, fc func() (string, int64), err error) {
+	sql, _ := fc()
+	l.mu.Lock()
+	l.stmts = append(l.stmts, sql)
+	l.mu.Unlock()
+}
+
+func (l *capturingLogger) all() string {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return strings.Join(l.stmts, "\n")
+}
+
+// probeRow is a minimal model satisfying models.ActiveRecord through the
+// same embeds a real app/admin model uses, so IndexAction sees exactly the
+// shape it is written against.
+type probeRow struct {
+	models.Model
+	models.ControlBy
+	Name string
+}
+
+func (probeRow) TableName() string                { return "action_probe_row" }
+func (e *probeRow) Generate() models.ActiveRecord { o := *e; return &o }
+func (e *probeRow) GetId() interface{}            { return e.Id }
+
+// probeIndexReq is a minimal dto.Index: no search tags, page defaults.
+type probeIndexReq struct {
+	dto.Pagination `search:"-"`
+}
+
+func (p *probeIndexReq) Generate() dto.Index        { return p }
+func (p *probeIndexReq) Bind(*gin.Context) error    { return nil }
+func (p *probeIndexReq) GetNeedSearch() interface{} { return *p }
+
+type pageEnvelope struct {
+	Code int32 `json:"code"`
+}
+
+// TestIndexActionAppliesDataPermission is an end-to-end guard core's own
+// test suite cannot provide. The five generic CRUD actions in this package
+// (create/delete/index/update/view.go) were not lowered to core (PRD 006
+// F3) - they still call actions.Permission directly, in this repository, on
+// a code path core knows nothing about. core's tests pin down what
+// Permission does for a given scope; nothing pinned down whether this
+// package's own Actions still remember to call it at all. This runs
+// IndexAction exactly as a real request would, against a real in-memory
+// database, and inspects the SQL GORM actually executed - not just that
+// the handler returned success, which it would just as happily do with no
+// filter applied at all.
+func TestIndexActionAppliesDataPermission(t *testing.T) {
+	previous := config.ApplicationConfig.EnableDP
+	config.ApplicationConfig.EnableDP = true
+	t.Cleanup(func() { config.ApplicationConfig.EnableDP = previous })
+
+	cl := &capturingLogger{Interface: gormlogger.Default.LogMode(gormlogger.Silent)}
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{Logger: cl})
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	if err := db.AutoMigrate(&probeRow{}); err != nil {
+		t.Fatalf("AutoMigrate: %v", err)
+	}
+
+	gin.SetMode(gin.TestMode)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodGet, "/", nil)
+	c.Set("db", db)
+	c.Set(actions.PermissionKey, &actions.DataPermission{DataScope: actions.DataScopeSelf, UserId: 7})
+
+	actions.IndexAction(&probeRow{}, &probeIndexReq{}, func() interface{} { return &[]probeRow{} })(c)
+
+	var body pageEnvelope
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decoding response body %q: %v", w.Body.String(), err)
+	}
+	if body.Code != http.StatusOK {
+		t.Fatalf("response code = %d, want %d; body=%s", body.Code, http.StatusOK, w.Body.String())
+	}
+
+	sql := cl.all()
+	const wantFragment = "action_probe_row.create_by = "
+	if !strings.Contains(sql, wantFragment) {
+		t.Fatalf("IndexAction did not apply the data-permission scope to its query; want SQL containing %q, got:\n%s", wantFragment, sql)
+	}
+}

--- a/common/actions/crud_shim_test.go
+++ b/common/actions/crud_shim_test.go
@@ -64,7 +64,12 @@ type probeIndexReq struct {
 	dto.Pagination `search:"-"`
 }
 
-func (p *probeIndexReq) Generate() dto.Index        { return p }
+// Generate returns a copy, the way every dto.Index in this repository does:
+// IndexAction closes over one instance and serves every request to the route
+// from it, so returning the receiver would share one struct across them. The
+// probe has to model that faithfully or it is not the shape IndexAction is
+// written against.
+func (p *probeIndexReq) Generate() dto.Index        { o := *p; return &o }
 func (p *probeIndexReq) Bind(*gin.Context) error    { return nil }
 func (p *probeIndexReq) GetNeedSearch() interface{} { return *p }
 
@@ -83,6 +88,14 @@ type pageEnvelope struct {
 // database, and inspects the SQL GORM actually executed - not just that
 // the handler returned success, which it would just as happily do with no
 // filter applied at all.
+func TestProbeIndexReqGenerateReturnsAFreshInstance(t *testing.T) {
+	p := &probeIndexReq{}
+	got := p.Generate()
+	if got == dto.Index(p) {
+		t.Fatal("Generate returned the receiver; IndexAction would share one instance across every request to the route")
+	}
+}
+
 func TestIndexActionAppliesDataPermission(t *testing.T) {
 	previous := config.ApplicationConfig.EnableDP
 	config.ApplicationConfig.EnableDP = true

--- a/common/actions/permission.go
+++ b/common/actions/permission.go
@@ -1,201 +1,48 @@
 package actions
 
 import (
-	"errors"
-
 	"github.com/gin-gonic/gin"
-	"github.com/go-admin-team/go-admin-core/v2/jwtauth/user"
-	log "github.com/go-admin-team/go-admin-core/v2/logger"
-	"github.com/go-admin-team/go-admin-core/v2/response"
-	"github.com/go-admin-team/go-admin-core/v2/sdk/config"
-	"github.com/go-admin-team/go-admin-core/v2/sdk/pkg"
 	"gorm.io/gorm"
+
+	contractactions "github.com/go-admin-team/go-admin-core/v2/sdk/contract/actions"
 )
 
-type DataPermission struct {
-	DataScope string
-	UserId    int
-	DeptId    int
-	RoleId    int
-}
+// DataPermission is a thin alias of go-admin-core's sdk/contract/actions
+// (PRD 006 F3/F5).
+type DataPermission = contractactions.DataPermission
 
-func PermissionAction() gin.HandlerFunc {
-	return func(c *gin.Context) {
-		// Permission() below returns the query untouched when data permission
-		// is off, so the lookup that feeds it has nothing to feed. It used to
-		// run anyway: a sys_user join on every list, detail, update and delete,
-		// with the result discarded.
-		if !config.ApplicationConfig.EnableDP {
-			c.Set(PermissionKey, new(DataPermission))
-			c.Next()
-			return
-		}
-
-		userId := user.GetUserIdStr(c)
-		if userId == "" {
-			c.Set(PermissionKey, new(DataPermission))
-			c.Next()
-			return
-		}
-
-		// The token already carries what the scope is decided by. Reading it
-		// there costs nothing, and goes no more stale than rolekey does - which
-		// Casbin has always read from the token.
-		if p, ok := permissionFromClaims(c); ok {
-			c.Set(PermissionKey, p)
-			c.Next()
-			return
-		}
-
-		db, err := pkg.GetOrm(c)
-		if err != nil {
-			log.Error(err)
-			// Same fix as the newDataPermission branch below: without Abort,
-			// gin's "return means continue" semantics send the request on to
-			// the business handler with PermissionKey never set. The caller
-			// then reads a zero-value DataPermission, which used to fall
-			// into Permission()'s fail-open default - a database hiccup
-			// silently turning into "see everything". PRD 006 F14/H1.
-			response.Error(c, 500, err, "权限范围鉴定错误")
-			c.Abort()
-			return
-		}
-		msgID := pkg.GenerateMsgIDFromContext(c)
-		p, err := newDataPermission(db, userId)
-		if err != nil {
-			log.Errorf("MsgID[%s] PermissionAction error: %s", msgID, err)
-			response.Error(c, 500, err, "权限范围鉴定错误")
-			c.Abort()
-			return
-		}
-		c.Set(PermissionKey, p)
-		c.Next()
-	}
-}
-
-// permissionFromClaims builds the scope from the token, reporting false when
-// the token predates deptid being carried. Such a token still exists until it
-// expires, and it has to keep working.
-func permissionFromClaims(c *gin.Context) (*DataPermission, bool) {
-	claims := user.ExtractClaims(c)
-	if claims["deptid"] == nil || claims["datascope"] == nil {
-		return nil, false
-	}
-	scope, ok := claims["datascope"].(string)
-	if !ok {
-		return nil, false
-	}
-	return &DataPermission{
-		DataScope: scope,
-		UserId:    user.GetUserId(c),
-		DeptId:    user.GetDeptId(c),
-		RoleId:    user.GetRoleId(c),
-	}, true
-}
-
-func newDataPermission(tx *gorm.DB, userId interface{}) (*DataPermission, error) {
-	var err error
-	p := &DataPermission{}
-
-	err = tx.Table("sys_user").
-		Select("sys_user.user_id", "sys_role.role_id", "sys_user.dept_id", "sys_role.data_scope").
-		Joins("left join sys_role on sys_role.role_id = sys_user.role_id").
-		Where("sys_user.user_id = ?", userId).
-		Scan(p).Error
-	if err != nil {
-		err = errors.New("获取用户数据出错 msg:" + err.Error())
-		return nil, err
-	}
-	return p, nil
-}
-
-// The five values sys_role.data_scope can hold. Front end's role editor
-// calls them by the same names (go-admin-ui's sys-role/index.vue): "1" is
-// 全部数据权限, "2" 自定义数据权限, "3" 本部门数据权限, "4" 本部门及以下数据权限,
-// "5" 仅本人数据权限.
-//
-// DataScopeAll has to be a named, explicit case in Permission below rather
-// than falling into default: it is a real, intentional configuration, not an
-// absence of one, and default's job after PRD 006 F14/H2 is to catch values
-// that are neither. Folding the two together is what made an unset or
-// corrupted data_scope indistinguishable from "show everything" in the first
-// place.
+// The five values sys_role.data_scope can hold, referenced directly from
+// go-admin-core's sdk/contract/actions rather than restated as literals -
+// see that package's DataScope* doc comment and PRD 006's hard constraint 4.
 const (
-	DataScopeAll      = "1"
-	DataScopeCustom   = "2"
-	DataScopeDept     = "3"
-	DataScopeDeptTree = "4"
-	DataScopeSelf     = "5"
+	DataScopeAll      = contractactions.DataScopeAll
+	DataScopeCustom   = contractactions.DataScopeCustom
+	DataScopeDept     = contractactions.DataScopeDept
+	DataScopeDeptTree = contractactions.DataScopeDeptTree
+	DataScopeSelf     = contractactions.DataScopeSelf
 )
 
-// IsValidDataScope reports whether s is one of the five values Permission
-// recognizes. Anything else lands in Permission's fail-closed default, so
-// code that persists data_scope (sys_role writes) should reject it before it
-// reaches the database rather than let a typo or an empty string surface
-// there silently.
-func IsValidDataScope(s string) bool {
-	switch s {
-	case DataScopeAll, DataScopeCustom, DataScopeDept, DataScopeDeptTree, DataScopeSelf:
-		return true
-	default:
-		return false
-	}
+// PermissionAction, Permission, GetPermissionFromContext and
+// IsValidDataScope forward to go-admin-core's sdk/contract/actions (PRD 006
+// F3/F5). create.go/delete.go/index.go/update.go/view.go in this package
+// (the generic CRUD actions, which do not move to core) call Permission and
+// GetPermissionFromContext by these same names and are unchanged by the
+// move: the names now resolve to forwards instead of local definitions, and
+// the behaviour is identical either way.
+func PermissionAction() gin.HandlerFunc {
+	return contractactions.PermissionAction()
 }
 
 func Permission(tableName string, p *DataPermission) func(db *gorm.DB) *gorm.DB {
-	return func(db *gorm.DB) *gorm.DB {
-		if !config.ApplicationConfig.EnableDP {
-			return db
-		}
-		switch p.DataScope {
-		case DataScopeAll:
-			return db
-		case DataScopeCustom:
-			return db.Where(tableName+".create_by in (select sys_user.user_id from sys_role_dept left join sys_user on sys_user.dept_id=sys_role_dept.dept_id where sys_role_dept.role_id = ?)", p.RoleId)
-		case DataScopeDept:
-			if p.DeptId <= 0 {
-				// A department id of 0 identifies no real department (see
-				// sys_dept.go: dept_path always starts with "/0/", the
-				// reserved root). Matching it literally would mean "every
-				// user whose dept_id happens to be unset", not "no one" -
-				// fail closed instead. PRD 006 F14/H3.
-				return db.Where("1 = 0")
-			}
-			return db.Where(tableName+".create_by in (SELECT user_id from sys_user where dept_id = ? )", p.DeptId)
-		case DataScopeDeptTree:
-			if p.DeptId <= 0 {
-				// dept_path is built as "/0/" + id + "/..." for every
-				// department (sys_dept.go), so a DeptId of 0 turns the LIKE
-				// pattern below into '%/0/%', which matches every row in
-				// sys_dept - full visibility instead of none. PRD 006
-				// F14/H3.
-				return db.Where("1 = 0")
-			}
-			return db.Where(tableName+".create_by in (SELECT user_id from sys_user where sys_user.dept_id in(select dept_id from sys_dept where dept_path like ? ))", "%/"+pkg.IntToString(p.DeptId)+"/%")
-		case DataScopeSelf:
-			return db.Where(tableName+".create_by = ?", p.UserId)
-		default:
-			// Unrecognized scope: never configured, corrupted data, or a
-			// value a future version adds and this one does not know yet.
-			// Fail closed - match nothing - instead of silently falling
-			// back to "see everything". PRD 006 F14/H2.
-			return db.Where("1 = 0")
-		}
-	}
+	return contractactions.Permission(tableName, p)
 }
 
-func getPermissionFromContext(c *gin.Context) *DataPermission {
-	p := new(DataPermission)
-	if pm, ok := c.Get(PermissionKey); ok {
-		switch pm.(type) {
-		case *DataPermission:
-			p = pm.(*DataPermission)
-		}
-	}
-	return p
-}
-
-// GetPermissionFromContext 提供非action写法数据范围约束
 func GetPermissionFromContext(c *gin.Context) *DataPermission {
-	return getPermissionFromContext(c)
+	return contractactions.GetPermissionFromContext(c)
+}
+
+// IsValidDataScope reports whether s is one of the five values Permission
+// recognizes. See go-admin-core's sdk/contract/actions.IsValidDataScope.
+func IsValidDataScope(s string) bool {
+	return contractactions.IsValidDataScope(s)
 }

--- a/common/actions/permission_test.go
+++ b/common/actions/permission_test.go
@@ -1,4 +1,4 @@
-package actions
+package actions_test
 
 import (
 	"net/http"
@@ -6,201 +6,101 @@ import (
 	"testing"
 
 	"github.com/gin-gonic/gin"
-	"github.com/glebarez/sqlite"
+
 	jwt "github.com/go-admin-team/go-admin-core/v2/jwtauth"
 	"github.com/go-admin-team/go-admin-core/v2/sdk/config"
-	"gorm.io/gorm"
+
+	"go-admin/common/actions"
 )
 
-// No database is placed in the context on purpose. The middleware needs one
-// only to run the sys_user join, so reaching the handler proves it did not.
-func runPermission(t *testing.T, claims jwt.MapClaims) (*DataPermission, bool) {
-	t.Helper()
-	gin.SetMode(gin.TestMode)
+// The detailed data-permission regression suite (claims parsing, the
+// GetOrm-unavailable abort, the SQL each data scope produces) now lives in
+// go-admin-core's sdk/contract/actions, alongside the logic itself (PRD 006
+// F3). What is left to test here is the shim's own wiring: that this
+// package's exported names still round-trip through the same *gin.Context
+// key core's PermissionAction and GetPermissionFromContext use.
+//
+// This file lives in package actions_test, an external test, deliberately:
+// it exercises PermissionAction and GetPermissionFromContext exactly as an
+// app/admin Service does, through this package's public API only, not
+// through anything internal a forward could paper over.
 
-	c, _ := gin.CreateTestContext(httptest.NewRecorder())
-	c.Request = httptest.NewRequest(http.MethodGet, "/", nil)
-	if claims != nil {
-		c.Set(jwt.JwtPayloadKey, claims)
-	}
-
-	PermissionAction()(c)
-
-	value, exists := c.Get(PermissionKey)
-	if !exists {
-		return nil, false
-	}
-	p, _ := value.(*DataPermission)
-	return p, true
-}
-
-// Permission() returns the query untouched when data permission is off, so the
-// lookup feeding it has nothing to feed. It used to run regardless: a sys_user
-// join on every list, detail, update and delete, discarded immediately.
-func TestNoLookupWhenDataPermissionIsOff(t *testing.T) {
-	previous := config.ApplicationConfig.EnableDP
-	config.ApplicationConfig.EnableDP = false
-	t.Cleanup(func() { config.ApplicationConfig.EnableDP = previous })
-
-	if _, ok := runPermission(t, jwt.MapClaims{"identity": float64(7)}); !ok {
-		t.Fatal("the request needed a database even though data permission is off")
-	}
-}
-
-func TestScopeComesFromTheTokenWhenItCarriesOne(t *testing.T) {
+// TestPermissionKeyMatchesWhatPermissionActionSets guards PRD 006's hard
+// constraint 4: PermissionKey must be declared as
+// `const PermissionKey = contractactions.PermissionKey`, a direct
+// reference, never a restated literal (see type.go). PermissionAction is
+// core's middleware and always writes under core's own key. This test reads
+// the value back with actions.PermissionKey exactly as code outside
+// GetPermissionFromContext would - c.Get(actions.PermissionKey) is a real,
+// if uncommon, way to read the value go-admin has always allowed, and it is
+// the one call site where an independently declared PermissionKey would
+// stop working without GetPermissionFromContext's own forward hiding it.
+//
+// If PermissionKey were ever re-declared as an independent literal in this
+// package, a later edit to core's copy would make this test fail without a
+// single byte of this package having changed - which is the silent-failure
+// mode hard constraint 4 exists to rule out (evaluation S2).
+func TestPermissionKeyMatchesWhatPermissionActionSets(t *testing.T) {
 	previous := config.ApplicationConfig.EnableDP
 	config.ApplicationConfig.EnableDP = true
 	t.Cleanup(func() { config.ApplicationConfig.EnableDP = previous })
 
-	p, ok := runPermission(t, jwt.MapClaims{
+	gin.SetMode(gin.TestMode)
+	c, _ := gin.CreateTestContext(httptest.NewRecorder())
+	c.Request = httptest.NewRequest(http.MethodGet, "/", nil)
+	c.Set(jwt.JwtPayloadKey, jwt.MapClaims{
 		"identity":  float64(7),
 		"roleid":    float64(3),
 		"deptid":    float64(5),
-		"datascope": "4",
+		"datascope": actions.DataScopeDeptTree,
 	})
+
+	actions.PermissionAction()(c)
+
+	value, ok := c.Get(actions.PermissionKey)
 	if !ok {
-		t.Fatal("the token carried the scope and a database was still needed")
+		t.Fatal("PermissionAction did not set the key actions.PermissionKey names; the two have diverged")
 	}
-	if p.DataScope != "4" || p.UserId != 7 || p.DeptId != 5 || p.RoleId != 3 {
-		t.Fatalf("scope read as %+v", p)
-	}
-}
-
-// A token minted before deptid was carried is still valid until it expires, and
-// has to keep working - by falling back to the query, which needs a database.
-func TestATokenWithoutDeptIdFallsBackToTheQuery(t *testing.T) {
-	previous := config.ApplicationConfig.EnableDP
-	config.ApplicationConfig.EnableDP = true
-	t.Cleanup(func() { config.ApplicationConfig.EnableDP = previous })
-
-	if _, ok := runPermission(t, jwt.MapClaims{
-		"identity":  float64(7),
-		"roleid":    float64(3),
-		"datascope": "4",
-	}); ok {
-		t.Fatal("an old token was served from claims it does not have")
+	p, ok := value.(*actions.DataPermission)
+	if !ok || p.DataScope != actions.DataScopeDeptTree || p.DeptId != 5 {
+		t.Fatalf("value under actions.PermissionKey = %#v, want a DataPermission carrying the token's scope", value)
 	}
 }
 
-// PRD 006 F14/H1. A token without deptid/datascope forces the fallback
-// query, which needs pkg.GetOrm(c) - and no "db" key is set in this
-// context, so GetOrm fails exactly as it would if a tenant's database were
-// unreachable. Before the fix, that error was logged and the handler ran
-// anyway with no data permission filter at all.
-func TestPermissionActionAbortsWhenDBIsUnavailable(t *testing.T) {
+// TestGetPermissionFromContextRoundTrips is the same guard from the other
+// exported entry point: GetPermissionFromContext must read back exactly
+// what PermissionAction wrote, both reached through this package's own
+// forwards rather than core's directly.
+func TestGetPermissionFromContextRoundTrips(t *testing.T) {
 	previous := config.ApplicationConfig.EnableDP
 	config.ApplicationConfig.EnableDP = true
 	t.Cleanup(func() { config.ApplicationConfig.EnableDP = previous })
 
 	gin.SetMode(gin.TestMode)
-	r := gin.New()
-	handlerReached := false
-	r.Use(func(c *gin.Context) {
-		c.Set(jwt.JwtPayloadKey, jwt.MapClaims{"identity": float64(7)})
-	})
-	r.Use(PermissionAction())
-	r.GET("/", func(c *gin.Context) {
-		handlerReached = true
-		c.Status(http.StatusOK)
+	c, _ := gin.CreateTestContext(httptest.NewRecorder())
+	c.Request = httptest.NewRequest(http.MethodGet, "/", nil)
+	c.Set(jwt.JwtPayloadKey, jwt.MapClaims{
+		"identity":  float64(7),
+		"roleid":    float64(3),
+		"deptid":    float64(5),
+		"datascope": actions.DataScopeSelf,
 	})
 
-	req := httptest.NewRequest(http.MethodGet, "/", nil)
-	w := httptest.NewRecorder()
-	r.ServeHTTP(w, req)
+	actions.PermissionAction()(c)
 
-	if handlerReached {
-		t.Fatal("the business handler ran with no database and no data permission filter set")
+	p := actions.GetPermissionFromContext(c)
+	if p.DataScope != actions.DataScopeSelf || p.UserId != 7 {
+		t.Fatalf("GetPermissionFromContext() = %+v, want DataScope=%q UserId=7", p, actions.DataScopeSelf)
 	}
 }
 
-// PRD 006 F14/H2 and H3. Table-driven over gorm DryRun so the exact SQL
-// Permission produces for each scope is pinned down, not just "some WHERE
-// clause got added".
-func TestPermissionScopes(t *testing.T) {
-	previous := config.ApplicationConfig.EnableDP
-	config.ApplicationConfig.EnableDP = true
-	t.Cleanup(func() { config.ApplicationConfig.EnableDP = previous })
-
-	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{DryRun: true})
-	if err != nil {
-		t.Fatalf("open: %v", err)
+func TestIsValidDataScope(t *testing.T) {
+	for _, s := range []string{actions.DataScopeAll, actions.DataScopeCustom, actions.DataScopeDept, actions.DataScopeDeptTree, actions.DataScopeSelf} {
+		if !actions.IsValidDataScope(s) {
+			t.Errorf("IsValidDataScope(%q) = false, want true", s)
+		}
 	}
-
-	const noRows = "SELECT * FROM `t` WHERE 1 = 0"
-
-	cases := []struct {
-		name string
-		p    *DataPermission
-		want string
-		vars []interface{}
-	}{
-		{
-			name: "all",
-			p:    &DataPermission{DataScope: DataScopeAll},
-			want: "SELECT * FROM `t`",
-		},
-		{
-			name: "custom",
-			p:    &DataPermission{DataScope: DataScopeCustom, RoleId: 3},
-			want: "SELECT * FROM `t` WHERE t.create_by in (select sys_user.user_id from sys_role_dept left join sys_user on sys_user.dept_id=sys_role_dept.dept_id where sys_role_dept.role_id = ?)",
-			vars: []interface{}{3},
-		},
-		{
-			name: "dept",
-			p:    &DataPermission{DataScope: DataScopeDept, DeptId: 5},
-			want: "SELECT * FROM `t` WHERE t.create_by in (SELECT user_id from sys_user where dept_id = ? )",
-			vars: []interface{}{5},
-		},
-		{
-			name: "dept-tree",
-			p:    &DataPermission{DataScope: DataScopeDeptTree, DeptId: 5},
-			want: "SELECT * FROM `t` WHERE t.create_by in (SELECT user_id from sys_user where sys_user.dept_id in(select dept_id from sys_dept where dept_path like ? ))",
-			vars: []interface{}{"%/5/%"},
-		},
-		{
-			name: "self",
-			p:    &DataPermission{DataScope: DataScopeSelf, UserId: 7},
-			want: "SELECT * FROM `t` WHERE t.create_by = ?",
-			vars: []interface{}{7},
-		},
-		// H2: an unrecognized scope must not read like "all data" any more.
-		{name: "unrecognized value", p: &DataPermission{DataScope: "6"}, want: noRows},
-		// H2/H1: the zero-value DataPermission is what getPermissionFromContext
-		// and the two "give up and continue" branches in PermissionAction hand
-		// out when nothing else is available.
-		{name: "zero value (no scope at all)", p: &DataPermission{}, want: noRows},
-		// H3: dept_path always starts with "/0/" (sys_dept.go), so DeptId 0
-		// must not be allowed to build a pattern that matches every row.
-		{name: "dept with DeptId 0", p: &DataPermission{DataScope: DataScopeDept, DeptId: 0}, want: noRows},
-		{name: "dept-tree with DeptId 0", p: &DataPermission{DataScope: DataScopeDeptTree, DeptId: 0}, want: noRows},
-		{name: "dept-tree with negative DeptId", p: &DataPermission{DataScope: DataScopeDeptTree, DeptId: -1}, want: noRows},
-	}
-
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			stmt := db.Session(&gorm.Session{DryRun: true}).
-				Table("t").
-				Scopes(Permission("t", tc.p)).
-				Find(&[]map[string]interface{}{}).
-				Statement
-
-			if stmt.SQL.String() != tc.want {
-				t.Errorf("SQL = %q, want %q", stmt.SQL.String(), tc.want)
-			}
-			if tc.vars == nil {
-				if len(stmt.Vars) != 0 {
-					t.Errorf("vars = %v, want none", stmt.Vars)
-				}
-				return
-			}
-			if len(stmt.Vars) != len(tc.vars) {
-				t.Fatalf("vars = %v, want %v", stmt.Vars, tc.vars)
-			}
-			for i := range tc.vars {
-				if stmt.Vars[i] != tc.vars[i] {
-					t.Errorf("vars[%d] = %v, want %v", i, stmt.Vars[i], tc.vars[i])
-				}
-			}
-		})
+	if actions.IsValidDataScope("6") {
+		t.Error(`IsValidDataScope("6") = true, want false`)
 	}
 }

--- a/common/actions/type.go
+++ b/common/actions/type.go
@@ -1,5 +1,13 @@
 package actions
 
-const (
-	PermissionKey = "dataPermission"
-)
+import contractactions "github.com/go-admin-team/go-admin-core/v2/sdk/contract/actions"
+
+// PermissionKey is a direct reference to go-admin-core's sdk/contract/actions
+// constant, not a restated literal - see that package's PermissionKey doc
+// comment. PRD 006's hard constraint 4 requires this form for exactly this
+// symbol: PermissionAction (below) sets the gin context key it owns, and
+// GetPermissionFromContext reads it back; an independently declared literal
+// here would let the two silently drift apart if core's copy ever changed
+// without this one following. common/actions/shim_test.go carries the
+// regression test for that failure mode.
+const PermissionKey = contractactions.PermissionKey

--- a/common/dto/auto_form.go
+++ b/common/dto/auto_form.go
@@ -1,74 +1,15 @@
 package dto
 
-type AutoForm struct {
-	Fields        []Field `json:"fields"`
-	FormRef       string  `json:"formRef"`
-	FormModel     string  `json:"formModel"`
-	Size          string  `json:"size"`
-	LabelPosition string  `json:"labelPosition"`
-	LabelWidth    int     `json:"labelWidth"`
-	FormRules     string  `json:"formRules"`
-	Gutter        int     `json:"gutter"`
-	Disabled      bool    `json:"disabled"`
-	Span          int     `json:"span"`
-	FormBtns      bool    `json:"formBtns"`
-}
+import contractdto "github.com/go-admin-team/go-admin-core/v2/sdk/contract/dto"
 
-type Config struct {
-	Label        string        `json:"label"`
-	LabelWidth   interface{}   `json:"labelWidth"`
-	ShowLabel    bool          `json:"showLabel"`
-	ChangeTag    bool          `json:"changeTag"`
-	Tag          string        `json:"tag"`
-	TagIcon      string        `json:"tagIcon"`
-	Required     bool          `json:"required"`
-	Layout       string        `json:"layout"`
-	Span         int           `json:"span"`
-	Document     string        `json:"document"`
-	RegList      []interface{} `json:"regList"`
-	FormId       int           `json:"formId"`
-	RenderKey    int64         `json:"renderKey"`
-	DefaultValue interface{}   `json:"defaultValue"`
-	ShowTip      bool          `json:"showTip,omitempty"`
-	ButtonText   string        `json:"buttonText,omitempty"`
-	FileSize     int           `json:"fileSize,omitempty"`
-	SizeUnit     string        `json:"sizeUnit,omitempty"`
-}
-
-type Option struct {
-	Label string `json:"label"`
-	Value string `json:"value"`
-}
-
-type Slot struct {
-	Prepend  string   `json:"prepend,omitempty"`
-	Append   string   `json:"append,omitempty"`
-	ListType bool     `json:"list-type,omitempty"`
-	Options  []Option `json:"options,omitempty"`
-}
-
-type Field struct {
-	Config        Config      `json:"__config__"`
-	Slot          Slot        `json:"__slot__"`
-	Placeholder   string      `json:"placeholder,omitempty"`
-	Style         Style       `json:"style,omitempty"`
-	Clearable     bool        `json:"clearable,omitempty"`
-	PrefixIcon    string      `json:"prefix-icon,omitempty"`
-	SuffixIcon    string      `json:"suffix-icon,omitempty"`
-	Maxlength     interface{} `json:"maxlength"`
-	ShowWordLimit bool        `json:"show-word-limit,omitempty"`
-	Readonly      bool        `json:"readonly,omitempty"`
-	Disabled      bool        `json:"disabled"`
-	VModel        string      `json:"__vModel__"`
-	Action        string      `json:"action,omitempty"`
-	Accept        string      `json:"accept,omitempty"`
-	Name          string      `json:"name,omitempty"`
-	AutoUpload    bool        `json:"auto-upload,omitempty"`
-	ListType      string      `json:"list-type,omitempty"`
-	Multiple      bool        `json:"multiple,omitempty"`
-	Filterable    bool        `json:"filterable,omitempty"`
-}
-
-type Style struct {
-	Width string `json:"width"`
-}
+// AutoForm and the types below describe a form built by go-admin-ui's form
+// designer. They are thin aliases of go-admin-core's sdk/contract/dto (PRD
+// 006 F2/F5).
+type (
+	AutoForm = contractdto.AutoForm
+	Config   = contractdto.Config
+	Option   = contractdto.Option
+	Slot     = contractdto.Slot
+	Field    = contractdto.Field
+	Style    = contractdto.Style
+)

--- a/common/dto/generate.go
+++ b/common/dto/generate.go
@@ -1,106 +1,11 @@
 package dto
 
-import (
-	vd "github.com/bytedance/go-tagexpr/v2/validator"
-	"net/http"
+import contractdto "github.com/go-admin-team/go-admin-core/v2/sdk/contract/dto"
 
-	"github.com/gin-gonic/gin"
-	"github.com/go-admin-team/go-admin-core/v2/sdk/api"
+// ObjectById, ObjectGetReq and ObjectDeleteReq are thin aliases of
+// go-admin-core's sdk/contract/dto (PRD 006 F2/F5).
+type (
+	ObjectById      = contractdto.ObjectById
+	ObjectGetReq    = contractdto.ObjectGetReq
+	ObjectDeleteReq = contractdto.ObjectDeleteReq
 )
-
-type ObjectById struct {
-	Id  int   `uri:"id"`
-	Ids []int `json:"ids"`
-}
-
-func (s *ObjectById) Bind(ctx *gin.Context) error {
-	var err error
-	log := api.GetRequestLogger(ctx)
-	err = ctx.ShouldBindUri(s)
-	if err != nil {
-		log.Warnf("ShouldBindUri error: %s", err.Error())
-		return err
-	}
-	if ctx.Request.Method == http.MethodDelete {
-		err = ctx.ShouldBind(&s)
-		if err != nil {
-			log.Warnf("ShouldBind error: %s", err.Error())
-			return err
-		}
-		if len(s.Ids) > 0 {
-			return nil
-		}
-		if s.Ids == nil {
-			s.Ids = make([]int, 0)
-		}
-		if s.Id != 0 {
-			s.Ids = append(s.Ids, s.Id)
-		}
-	}
-	if err = vd.Validate(s); err != nil {
-		log.Errorf("Validate error: %s", err.Error())
-		return err
-	}
-	return err
-}
-
-func (s *ObjectById) GetId() interface{} {
-	if len(s.Ids) > 0 {
-		s.Ids = append(s.Ids, s.Id)
-		return s.Ids
-	}
-	return s.Id
-}
-
-type ObjectGetReq struct {
-	Id int `uri:"id"`
-}
-
-func (s *ObjectGetReq) Bind(ctx *gin.Context) error {
-	var err error
-	log := api.GetRequestLogger(ctx)
-	err = ctx.ShouldBindUri(s)
-	if err != nil {
-		log.Warnf("ShouldBindUri error: %s", err.Error())
-		return err
-	}
-	if err = vd.Validate(s); err != nil {
-		log.Errorf("Validate error: %s", err.Error())
-		return err
-	}
-	return err
-}
-
-func (s *ObjectGetReq) GetId() interface{} {
-	return s.Id
-}
-
-type ObjectDeleteReq struct {
-	Ids []int `json:"ids"`
-}
-
-func (s *ObjectDeleteReq) Bind(ctx *gin.Context) error {
-	var err error
-	log := api.GetRequestLogger(ctx)
-	err = ctx.ShouldBind(&s)
-	if err != nil {
-		log.Warnf("ShouldBind error: %s", err.Error())
-		return err
-	}
-	if len(s.Ids) > 0 {
-		return nil
-	}
-	if s.Ids == nil {
-		s.Ids = make([]int, 0)
-	}
-
-	if err = vd.Validate(s); err != nil {
-		log.Errorf("Validate error: %s", err.Error())
-		return err
-	}
-	return err
-}
-
-func (s *ObjectDeleteReq) GetId() interface{} {
-	return s.Ids
-}

--- a/common/dto/order.go
+++ b/common/dto/order.go
@@ -2,11 +2,13 @@ package dto
 
 import (
 	"gorm.io/gorm"
-	"gorm.io/gorm/clause"
+
+	contractdto "github.com/go-admin-team/go-admin-core/v2/sdk/contract/dto"
 )
 
+// OrderDest forwards to go-admin-core's sdk/contract/dto (PRD 006 F2/F5). A
+// function cannot be aliased the way a type can, so this is a pure
+// pass-through rather than a `func X = pkg.X` form Go does not have.
 func OrderDest(sort string, bl bool) func(db *gorm.DB) *gorm.DB {
-	return func(db *gorm.DB) *gorm.DB {
-		return db.Order(clause.OrderByColumn{Column: clause.Column{Name: sort}, Desc: bl})
-	}
+	return contractdto.OrderDest(sort, bl)
 }

--- a/common/dto/pagination.go
+++ b/common/dto/pagination.go
@@ -1,20 +1,7 @@
 package dto
 
-type Pagination struct {
-	PageIndex int `form:"pageIndex"`
-	PageSize  int `form:"pageSize"`
-}
+import contractdto "github.com/go-admin-team/go-admin-core/v2/sdk/contract/dto"
 
-func (m *Pagination) GetPageIndex() int {
-	if m.PageIndex <= 0 {
-		m.PageIndex = 1
-	}
-	return m.PageIndex
-}
-
-func (m *Pagination) GetPageSize() int {
-	if m.PageSize <= 0 {
-		m.PageSize = 10
-	}
-	return m.PageSize
-}
+// Pagination is a thin alias of go-admin-core's sdk/contract/dto (PRD 006
+// F2/F5).
+type Pagination = contractdto.Pagination

--- a/common/dto/search.go
+++ b/common/dto/search.go
@@ -1,80 +1,31 @@
 package dto
 
 import (
-	"github.com/go-admin-team/go-admin-core/v2/tools/search"
-	"go-admin/common/global"
 	"gorm.io/gorm"
+
+	contractdto "github.com/go-admin-team/go-admin-core/v2/sdk/contract/dto"
 )
 
-type GeneralDelDto struct {
-	Id  int   `uri:"id" json:"id" validate:"required"`
-	Ids []int `json:"ids"`
-}
+// GeneralDelDto and GeneralGetDto are thin aliases of go-admin-core's
+// sdk/contract/dto (PRD 006 F2/F5).
+type (
+	GeneralDelDto = contractdto.GeneralDelDto
+	GeneralGetDto = contractdto.GeneralGetDto
+)
 
-func (g GeneralDelDto) GetIds() []int {
-	ids := make([]int, 0)
-	// Id 此前在 else 分支里被重复追加：仅传 Id 时会得到 [5 5]，
-	// 同一条记录被执行两次删除
-	if g.Id > 0 {
-		ids = append(ids, g.Id)
-	}
-	for _, id := range g.Ids {
-		if id > 0 {
-			ids = append(ids, id)
-		}
-	}
-	if len(ids) == 0 {
-		//方式全部删除
-		ids = append(ids, 0)
-	}
-	return ids
-}
-
-type GeneralGetDto struct {
-	Id int `uri:"id" json:"id" validate:"required"`
-}
-
+// MakeCondition and Paginate forward to go-admin-core's sdk/contract/dto
+// (PRD 006 F2/F5). This file used to read go-admin/common/global.Driver to
+// pick the SQL dialect MakeCondition resolves search tags against; the
+// lowered version instead reads db.Dialector.Name() from inside the closure
+// it returns, which is always the driver the caller's own *gorm.DB is bound
+// to - correct even when a multi-tenant host has more than one database
+// open with different drivers, which a single package-level variable could
+// never be. global.Driver itself is untouched and still readable, but
+// nothing in this package reads it anymore.
 func MakeCondition(q interface{}) func(db *gorm.DB) *gorm.DB {
-	return func(db *gorm.DB) *gorm.DB {
-		condition := &search.GormCondition{
-			GormPublic: search.GormPublic{},
-			Join:       make([]*search.GormJoin, 0),
-		}
-		search.ResolveSearchQuery(global.Driver, q, condition)
-		for _, join := range condition.Join {
-			if join == nil {
-				continue
-			}
-			db = db.Joins(join.JoinOn)
-			for k, v := range join.Where {
-				db = db.Where(k, v...)
-			}
-			for k, v := range join.Or {
-				db = db.Or(k, v...)
-			}
-			for _, o := range join.Order {
-				db = db.Order(o)
-			}
-		}
-		for k, v := range condition.Where {
-			db = db.Where(k, v...)
-		}
-		for k, v := range condition.Or {
-			db = db.Or(k, v...)
-		}
-		for _, o := range condition.Order {
-			db = db.Order(o)
-		}
-		return db
-	}
+	return contractdto.MakeCondition(q)
 }
 
 func Paginate(pageSize, pageIndex int) func(db *gorm.DB) *gorm.DB {
-	return func(db *gorm.DB) *gorm.DB {
-		offset := (pageIndex - 1) * pageSize
-		if offset < 0 {
-			offset = 0
-		}
-		return db.Offset(offset).Limit(pageSize)
-	}
+	return contractdto.Paginate(pageSize, pageIndex)
 }

--- a/common/dto/type.go
+++ b/common/dto/type.go
@@ -1,21 +1,10 @@
 package dto
 
-import (
-	"github.com/gin-gonic/gin"
-	"go-admin/common/models"
+import contractdto "github.com/go-admin-team/go-admin-core/v2/sdk/contract/dto"
+
+// Index and Control are thin aliases of go-admin-core's sdk/contract/dto
+// (PRD 006 F2/F5).
+type (
+	Index   = contractdto.Index
+	Control = contractdto.Control
 )
-
-type Index interface {
-	Generate() Index
-	Bind(ctx *gin.Context) error
-	GetPageIndex() int
-	GetPageSize() int
-	GetNeedSearch() interface{}
-}
-
-type Control interface {
-	Generate() Control
-	Bind(ctx *gin.Context) error
-	GenerateM() (models.ActiveRecord, error)
-	GetId() interface{}
-}

--- a/common/global/adm.go
+++ b/common/global/adm.go
@@ -7,5 +7,12 @@ const (
 
 var (
 	// Driver 数据库驱动
+	//
+	// Deprecated: common/dto.MakeCondition stopped reading this after PRD
+	// 006 F2/F5 - it now takes the dialect from the *gorm.DB passed to the
+	// scope it returns instead of this process-wide variable. Driver is
+	// still set (common/database/initialize.go) and still readable for fork
+	// code that reads it directly, but it is no longer this framework's own
+	// path to the current SQL dialect.
 	Driver string
 )

--- a/common/models/by.go
+++ b/common/models/by.go
@@ -1,41 +1,13 @@
 package models
 
-import (
-	"time"
+import contractmodels "github.com/go-admin-team/go-admin-core/v2/sdk/contract/models"
 
-	"gorm.io/plugin/soft_delete"
+// ControlBy, Model and ModelTime are thin aliases of go-admin-core's
+// sdk/contract/models (PRD 006 F1/F5). A type alias is the same type, not a
+// new one, so every model that embeds these keeps its GORM tags, JSON tags
+// and method set untouched.
+type (
+	ControlBy = contractmodels.ControlBy
+	Model     = contractmodels.Model
+	ModelTime = contractmodels.ModelTime
 )
-
-type ControlBy struct {
-	CreateBy int `json:"createBy" gorm:"index;comment:创建者"`
-	UpdateBy int `json:"updateBy" gorm:"index;comment:更新者"`
-}
-
-// SetCreateBy 设置创建人id
-func (e *ControlBy) SetCreateBy(createBy int) {
-	e.CreateBy = createBy
-}
-
-// SetUpdateBy 设置修改人id
-func (e *ControlBy) SetUpdateBy(updateBy int) {
-	e.UpdateBy = updateBy
-}
-
-type Model struct {
-	Id int `json:"id" gorm:"primaryKey;autoIncrement;comment:主键编码"`
-}
-
-type ModelTime struct {
-	CreatedAt time.Time `json:"createdAt" gorm:"comment:创建时间"`
-	UpdatedAt time.Time `json:"updatedAt" gorm:"comment:最后更新时间"`
-
-	// DeletedAt is milliseconds since the epoch, zero while the row is live,
-	// and never null.
-	//
-	// A nullable marker cannot take part in a unique index. Two live rows are
-	// (name, NULL) and (name, NULL), and NULL is not equal to NULL, so the
-	// index permits both — it looks like a constraint and enforces nothing.
-	// With zero for live rows the pair collides, while two deletions of the
-	// same name differ by their timestamps and both remain.
-	DeletedAt soft_delete.DeletedAt `json:"-" gorm:"softDelete:milli;index;comment:删除时间"`
-}

--- a/common/models/menu.go
+++ b/common/models/menu.go
@@ -1,11 +1,15 @@
 package models
 
-// Menu 菜单中的类型枚举值
+import contractmodels "github.com/go-admin-team/go-admin-core/v2/sdk/contract/models"
+
+// Directory, Menu and Button are the menu type enum values used by
+// sys_menu.menu_type, referenced directly from go-admin-core's
+// sdk/contract/models rather than restated as literals: PRD 006's hard
+// constraint 4 requires `const X = pkg.X` for exactly this reason - two
+// independently written copies of the same value can be edited out of step,
+// where a direct reference cannot.
 const (
-	// Directory 目录
-	Directory string = "M"
-	// Menu 菜单
-	Menu      string = "C"
-	// Button 按钮
-	Button    string = "F"
+	Directory = contractmodels.Directory
+	Menu      = contractmodels.Menu
+	Button    = contractmodels.Button
 )

--- a/common/models/migrate.go
+++ b/common/models/migrate.go
@@ -1,23 +1,10 @@
 package models
 
-import "time"
+import contractmodels "github.com/go-admin-team/go-admin-core/v2/sdk/contract/models"
 
-type Migration struct {
-	Version   string    `gorm:"primaryKey"`
-	ApplyTime time.Time `gorm:"autoCreateTime"`
-
-	// AppCode identifies which app registered this migration. The empty string
-	// means the framework itself.
-	//
-	// NOT NULL DEFAULT '' rather than a nullable column, and the difference is
-	// not cosmetic: on a nullable column the rows that already exist when
-	// AutoMigrate adds it hold NULL, and the first SELECT scanning one into
-	// this string field fails with "converting NULL to string is unsupported".
-	// The default is what makes "existing history belongs to the framework"
-	// true without a backfill script anyone could forget to run.
-	AppCode string `gorm:"type:varchar(64);not null;default:'';index:idx_sys_migration_app_code;comment:AppCode"`
-}
-
-func (Migration) TableName() string {
-	return "sys_migration"
-}
+// Migration is the sys_migration row model (data). It is unrelated to
+// cmd/migrate/migration.Migration, the in-process registration table this
+// package's TableName has nothing to do with - see
+// go-admin-core's sdk/contract/models.Migration doc comment for why the two
+// share a name.
+type Migration = contractmodels.Migration

--- a/common/models/response.go
+++ b/common/models/response.go
@@ -1,30 +1,10 @@
 package models
 
-type Response struct {
-	// 代码
-	Code int `json:"code" example:"200"`
-	// 数据集
-	Data interface{} `json:"data"`
-	// 消息
-	Msg       string `json:"msg"`
-	RequestId string `json:"requestId"`
-}
+import contractmodels "github.com/go-admin-team/go-admin-core/v2/sdk/contract/models"
 
-type Page struct {
-	List      interface{} `json:"list"`
-	Count     int         `json:"count"`
-	PageIndex int         `json:"pageIndex"`
-	PageSize  int         `json:"pageSize"`
-}
-
-// ReturnOK 正常返回
-func (res *Response) ReturnOK() *Response {
-	res.Code = 200
-	return res
-}
-
-// ReturnError 错误返回
-func (res *Response) ReturnError(code int) *Response {
-	res.Code = code
-	return res
-}
+// Response and Page are thin aliases of go-admin-core's sdk/contract/models
+// (PRD 006 F1/F5).
+type (
+	Response = contractmodels.Response
+	Page     = contractmodels.Page
+)

--- a/common/models/type.go
+++ b/common/models/type.go
@@ -1,11 +1,12 @@
 package models
 
-import "gorm.io/gorm/schema"
+import contractmodels "github.com/go-admin-team/go-admin-core/v2/sdk/contract/models"
 
-type ActiveRecord interface {
-	schema.Tabler
-	SetCreateBy(createBy int)
-	SetUpdateBy(updateBy int)
-	Generate() ActiveRecord
-	GetId() interface{}
-}
+// ActiveRecord is self-referencing (Generate() ActiveRecord), which is why
+// it must stay a type alias rather than a defined type: aliasing preserves
+// identity with go-admin-core's sdk/contract/models.ActiveRecord, so a
+// model whose Generate() returns that interface still satisfies this one. A
+// defined type here would break every implementer's method set - see
+// go-admin-core's sdk/contract/models package tests for the counterproof
+// (PRD 006 counterproof A).
+type ActiveRecord = contractmodels.ActiveRecord

--- a/common/models/user.go
+++ b/common/models/user.go
@@ -1,42 +1,7 @@
 package models
 
-import (
-	"gorm.io/gorm"
+import contractmodels "github.com/go-admin-team/go-admin-core/v2/sdk/contract/models"
 
-	"github.com/go-admin-team/go-admin-core/v2/sdk/pkg"
-)
-
-// BaseUser 密码登录基础用户
-type BaseUser struct {
-	Username     string `json:"username" gorm:"type:varchar(100);comment:用户名"`
-	Salt         string `json:"-" gorm:"type:varchar(255);comment:加盐;<-"`
-	PasswordHash string `json:"-" gorm:"type:varchar(128);comment:密码hash;<-"`
-	Password     string `json:"password" gorm:"-"`
-}
-
-// SetPassword 设置密码
-func (u *BaseUser) SetPassword(value string) {
-	u.Password = value
-	u.generateSalt()
-	u.PasswordHash = u.GetPasswordHash()
-}
-
-// GetPasswordHash 获取密码hash
-func (u *BaseUser) GetPasswordHash() string {
-	passwordHash, err := pkg.SetPassword(u.Password, u.Salt)
-	if err != nil {
-		return ""
-	}
-	return passwordHash
-}
-
-// generateSalt 生成加盐值
-func (u *BaseUser) generateSalt() {
-	u.Salt = pkg.GenerateRandomKey16()
-}
-
-// Verify 验证密码
-func (u *BaseUser) Verify(db *gorm.DB, tableName string) bool {
-	db.Table(tableName).Where("username = ?", u.Username).First(u)
-	return u.GetPasswordHash() == u.PasswordHash
-}
+// BaseUser is a thin alias of go-admin-core's sdk/contract/models (PRD 006
+// F1/F5).
+type BaseUser = contractmodels.BaseUser

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/casbin/casbin/v3 v3.8.1
 	github.com/gin-gonic/gin v1.12.0
 	github.com/glebarez/sqlite v1.11.0
-	github.com/go-admin-team/go-admin-core/v2 v2.4.1
+	github.com/go-admin-team/go-admin-core/v2 v2.5.0
 	github.com/google/uuid v1.6.0
 	github.com/huaweicloud/huaweicloud-sdk-go-obs v3.26.6+incompatible
 	github.com/mssola/user_agent v0.6.0
@@ -32,7 +32,6 @@ require (
 	gorm.io/driver/sqlite v1.6.0
 	gorm.io/driver/sqlserver v1.6.4
 	gorm.io/gorm v1.31.2
-	gorm.io/plugin/soft_delete v1.2.1
 )
 
 require (
@@ -142,6 +141,7 @@ require (
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gorm.io/plugin/dbresolver v1.6.2 // indirect
+	gorm.io/plugin/soft_delete v1.2.1 // indirect
 	modernc.org/fileutil v1.3.40 // indirect
 	modernc.org/libc v1.67.4 // indirect
 	modernc.org/mathutil v1.7.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -145,8 +145,8 @@ github.com/glebarez/go-sqlite v1.22.0 h1:uAcMJhaA6r3LHMTFgP0SifzgXg46yJkgxqyuyec
 github.com/glebarez/go-sqlite v1.22.0/go.mod h1:PlBIdHe0+aUEFn+r2/uthrWq4FxbzugL0L8Li6yQJbc=
 github.com/glebarez/sqlite v1.11.0 h1:wSG0irqzP6VurnMEpFGer5Li19RpIRi2qvQz++w0GMw=
 github.com/glebarez/sqlite v1.11.0/go.mod h1:h8/o8j5wiAsqSPoWELDUdJXhjAhsVliSn7bWZjOhrgQ=
-github.com/go-admin-team/go-admin-core/v2 v2.4.1 h1:69QprBVMcQzjVP0UksCwi//A0qh8gwcIHcwHmABPp2U=
-github.com/go-admin-team/go-admin-core/v2 v2.4.1/go.mod h1:YiJr2+vqC9qV5AoGeL+1W55h3XZ99CB5xWnP3Wo8c5g=
+github.com/go-admin-team/go-admin-core/v2 v2.5.0 h1:aD1SALklBxizGB9u8cOgm4OT8z656FM83F4fD6dMz9g=
+github.com/go-admin-team/go-admin-core/v2 v2.5.0/go.mod h1:LG/XvEfOplbuadKrPTPm0Nu5pN06aQUNZZC3ao4B4gs=
 github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-kit/kit v0.9.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-kit/kit v0.10.0/go.mod h1:xUsJbQ/Fp4kEt7AFgCuvyX4a71u8h9jB8tj/ORgOZ7o=


### PR DESCRIPTION
> 依赖 [go-admin-core v2.5.0](https://github.com/go-admin-team/go-admin-core/releases/tag/v2.5.0)（已发布）。`go.mod` 直接 require 该版本，无 `replace`。

## 做了什么

`common/models`、`common/dto` 与 `common/actions` 的数据权限部分改为 core 契约包的**纯类型别名转发**。5 个通用 CRUD Action 未下沉，仍在本仓库。

## 为什么是别名，不是 defined type

`type X pkg.Y` 保留字段、**丢掉方法集**，任何嵌入它的类型会不再满足此前满足的接口。编译器只在方法集被实际使用的地方报错——本仓库对一部分契约类型通过接口使唤、另一部分完全没使唤，后者在这里编译得好好的，**到 fork 或第三方应用里才炸**。

实测：把 `ControlBy` 改成 defined type，`go build ./...` 立刻在 11 处报 `missing method SetCreateBy`。已恢复。

## 常量不能别名

Go 的类型别名管不到常量。`PermissionKey` 若在两侧各声明一次同值字面量，就是**两个不同的 context key**：`c.Set` 与 `c.Get` 落在不同键上，数据权限静默失效。因此写作 `const PermissionKey = contractactions.PermissionKey`，直接引用而非重述。

反证时发现一件事值得记：这样写错之后，`GetPermissionFromContext` 仍然正常——它是纯转发，两端都落在 core 内部同一个真实常量上。真正会中招的是绕过它、直接 `c.Get(actions.PermissionKey)` 的第三方写法。

## 验收

**零改动**是这批的最高判据——fork 用户合并后不改一行即可编译：

```bash
IMPORT_POINTS=$(grep -rl '"go-admin/common/models"\|"go-admin/common/dto"\|"go-admin/common/actions"' \
  --include="*.go" . | grep -v '^./common/models/\|^./common/dto/\|^./common/actions/')
git diff --exit-code -- $IMPORT_POINTS   # 70 个文件，通过
git diff --exit-code -- app/demo         # 通过
```

用 `git diff --exit-code` 而不是 `go build` 判定：编译通过只说明能编译，不说明没改。

## 测试的位置变了

原 `common/actions` 的详细回归测试（claims 解析、DB 不可用中止、五档 scope 的 SQL 断言）随实现搬进 core，成为那里的永久回归测试。

本仓库换成两类：薄壳接线是否正确，以及**数据权限经由一个真实 CRUD Action 是否仍然生效**——5 个 Action 没有下沉，「Action 有没有把 DataPermission 正确传进去」这条路径 core 的测试守不住。后者通过包装 `gorm.io/gorm/logger.Interface` 捕获实际执行的 SQL 来断言；删掉 `IndexAction` 里的 `Permission(...)` 调用，捕获到的 SQL 变成没有任何 WHERE，测试变红。

## 顺带

`common/dto` 不再读 `common/global.Driver`——core 版本改从 scope 闭包里的 `db.Dialector.Name()` 取。原先那个包级变量保存的是配置 map 迭代到的第一个数据库的驱动，而 map 迭代无序，多租户使用不同驱动时并不确定。`global.Driver` 保留可读并标注 Deprecated。
