### PR TITLE
fix🐛: JWT 中间件注册成了取不出来的形状

### DIFF
--- a/app/admin/router/init_router.go
+++ b/app/admin/router/init_router.go
@@ -25,11 +25,9 @@ func InitRouter() {
 		os.Exit(-1)
 	}
 
-	// the jwt middleware
-	authMiddleware, err := common.AuthInit()
-	if err != nil {
-		log.Fatalf("JWT Init Error, %s", err.Error())
-	}
+	// the jwt middleware: shared instance InitMiddleware built at startup,
+	// not one built here per module (see common/middleware.GetAuthMiddleware).
+	authMiddleware := common.GetAuthMiddleware()
 
 	// 注册系统路由
 	InitSysRouter(r, authMiddleware)

--- a/app/demo/router/router.go
+++ b/app/demo/router/router.go
@@ -33,11 +33,9 @@ func InitRouter() {
 		os.Exit(-1)
 	}
 
-	// the jwt middleware
-	authMiddleware, err := common.AuthInit()
-	if err != nil {
-		log.Fatalf("JWT Init Error, %s", err.Error())
-	}
+	// the jwt middleware: shared instance InitMiddleware built at startup,
+	// not one built here per module (see common/middleware.GetAuthMiddleware).
+	authMiddleware := common.GetAuthMiddleware()
 
 	// 注册业务路由
 	InitBusinessRouter(r, authMiddleware)

--- a/app/jobs/router/init_router.go
+++ b/app/jobs/router/init_router.go
@@ -26,10 +26,9 @@ func InitRouter() {
 		os.Exit(-1)
 	}
 
-	authMiddleware, err := common.AuthInit()
-	if err != nil {
-		log.Fatalf("JWT Init Error, %s", err.Error())
-	}
+	// the jwt middleware: shared instance InitMiddleware built at startup,
+	// not one built here per module (see common/middleware.GetAuthMiddleware).
+	authMiddleware := common.GetAuthMiddleware()
 
 	// 注册业务路由
 	initRouter(r, authMiddleware)

--- a/app/other/router/init_router.go
+++ b/app/other/router/init_router.go
@@ -25,10 +25,9 @@ func InitRouter() {
 		os.Exit(-1)
 	}
 	// the jwt middleware
-	authMiddleware, err := common.AuthInit()
-	if err != nil {
-		log.Fatalf("JWT Init Error, %s", err.Error())
-	}
+	// the jwt middleware: shared instance InitMiddleware built at startup,
+	// not one built here per module (see common/middleware.GetAuthMiddleware).
+	authMiddleware := common.GetAuthMiddleware()
 
 	// 注册业务路由
 	// TODO: 这里可存放业务路由，里边并无实际路由只有演示代码

--- a/common/middleware/auth.go
+++ b/common/middleware/auth.go
@@ -3,10 +3,18 @@ package middleware
 import (
 	"time"
 
-	"github.com/go-admin-team/go-admin-core/v2/sdk/config"
 	jwt "github.com/go-admin-team/go-admin-core/v2/jwtauth"
+	log "github.com/go-admin-team/go-admin-core/v2/logger"
+	"github.com/go-admin-team/go-admin-core/v2/sdk/config"
 	"go-admin/common/middleware/handler"
 )
+
+// authMiddleware is the single JWT middleware instance the whole process
+// shares. InitMiddleware builds it once, before any module registers its
+// routes; GetAuthMiddleware is how a module gets it back instead of calling
+// AuthInit itself and building another, functionally-equivalent-but-distinct
+// instance.
+var authMiddleware *jwt.GinJWTMiddleware
 
 // AuthInit jwt验证new
 func AuthInit() (*jwt.GinJWTMiddleware, error) {
@@ -33,4 +41,23 @@ func AuthInit() (*jwt.GinJWTMiddleware, error) {
 		TimeFunc:        time.Now,
 	})
 
+}
+
+// GetAuthMiddleware returns the shared JWT middleware instance InitMiddleware
+// built at startup. Application modules (app/admin, app/jobs, app/other,
+// app/demo) call this instead of AuthInit so their router chains - which
+// still need the instance itself for authMiddleware.MiddlewareFunc() and
+// authMiddleware.LoginHandler, not just the bound closure registered under
+// sdk.Runtime's JwtTokenCheck key - end up using the same instance the host
+// registered, rather than one each.
+//
+// It fails loudly instead of returning nil: an InitRouter that runs before
+// InitMiddleware has a real startup-ordering bug, not a case to paper over
+// with a nil *jwt.GinJWTMiddleware that would panic much further down the
+// call chain with a far less useful stack trace.
+func GetAuthMiddleware() *jwt.GinJWTMiddleware {
+	if authMiddleware == nil {
+		log.Fatal("JWT middleware not initialized; InitMiddleware must run before any module's InitRouter")
+	}
+	return authMiddleware
 }

--- a/common/middleware/init.go
+++ b/common/middleware/init.go
@@ -2,15 +2,20 @@ package middleware
 
 import (
 	"github.com/gin-gonic/gin"
-	jwt "github.com/go-admin-team/go-admin-core/v2/jwtauth"
+	log "github.com/go-admin-team/go-admin-core/v2/logger"
 	"github.com/go-admin-team/go-admin-core/v2/sdk"
+	"github.com/go-admin-team/go-admin-core/v2/sdk/runtime"
 	"go-admin/common/actions"
 )
 
+// These alias core's own constants (see sdk/runtime.GetHandlerFunc's contract
+// doc, section 9) rather than redeclaring the same three strings, so a typo
+// here can no longer split registration and lookup into two different keys
+// that both happen to compile.
 const (
-	JwtTokenCheck   string = "JwtToken"
-	RoleCheck       string = "AuthCheckRole"
-	PermissionCheck string = "PermissionAction"
+	JwtTokenCheck   = runtime.JwtTokenCheck
+	RoleCheck       = runtime.RoleCheck
+	PermissionCheck = runtime.PermissionCheck
 )
 
 func InitMiddleware(r *gin.Engine) {
@@ -29,7 +34,26 @@ func InitMiddleware(r *gin.Engine) {
 	r.Use(Secure)
 	// 链路追踪
 	//r.Use(middleware.Trace())
-	sdk.Runtime.SetMiddleware(JwtTokenCheck, (*jwt.GinJWTMiddleware).MiddlewareFunc)
+
+	// Build the shared JWT middleware instance here, before any module
+	// registers routes (initRouter runs ahead of runStartupHooks, which is
+	// what invokes each module's InitRouter - see cmd/api/server.go). Doing
+	// it once here, instead of once per module via AuthInit, is what makes
+	// GetAuthMiddleware and sdk.Runtime.GetHandlerFunc(JwtTokenCheck) both
+	// resolve to a single, meaningful instance instead of "whichever module
+	// happened to initialize last".
+	//
+	// SetMiddleware must be given a bound closure (authMiddleware.MiddlewareFunc()),
+	// not the unbound method expression (*jwt.GinJWTMiddleware).MiddlewareFunc:
+	// the latter has no receiver bound to it, so GetHandlerFunc's type
+	// assertion to gin.HandlerFunc always fails for it.
+	var err error
+	authMiddleware, err = AuthInit()
+	if err != nil {
+		// A process with no JWT middleware must not start serving requests.
+		log.Fatalf("JWT Init Error, %s", err.Error())
+	}
+	sdk.Runtime.SetMiddleware(JwtTokenCheck, authMiddleware.MiddlewareFunc())
 	sdk.Runtime.SetMiddleware(RoleCheck, AuthCheckRole())
 	sdk.Runtime.SetMiddleware(PermissionCheck, actions.PermissionAction())
 }

--- a/common/middleware/init_test.go
+++ b/common/middleware/init_test.go
@@ -1,0 +1,77 @@
+package middleware
+
+import (
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/go-admin-team/go-admin-core/v2/sdk"
+	"github.com/go-admin-team/go-admin-core/v2/sdk/config"
+	"github.com/go-admin-team/go-admin-core/v2/sdk/runtime"
+)
+
+// freshRuntime hands the test its own Runtime and puts the old one back, the
+// same pattern cmd/api/server_test.go uses: sdk.Runtime is a process-wide
+// singleton, and a test that registers into it would otherwise leak state
+// into every other test in the binary.
+func freshRuntime(t *testing.T) {
+	t.Helper()
+	previous := sdk.Runtime
+	t.Cleanup(func() { sdk.Runtime = previous })
+	sdk.Runtime = runtime.NewConfig()
+}
+
+// TestInitMiddlewareRegistersUsableJwtHandlerFunc is the reverse proof for
+// hoisting the JWT instance's construction into InitMiddleware:
+// sdk.Runtime.GetHandlerFunc(JwtTokenCheck) must hand back ok=true and a
+// non-nil gin.HandlerFunc, not just something GetMiddleware can return as an
+// untyped interface{}.
+//
+// Before this change, InitMiddleware registered the unbound method
+// expression (*jwt.GinJWTMiddleware).MiddlewareFunc under this key - a value
+// with no receiver bound to it, which is not a gin.HandlerFunc no matter how
+// a caller asserts its type. Reverting the registration below to that
+// expression makes GetHandlerFunc report ok=false; it does not fail to
+// compile, because (*jwt.GinJWTMiddleware).MiddlewareFunc has a well-formed,
+// unrelated method-expression type that SetMiddleware's interface{} param
+// happily accepts.
+func TestInitMiddlewareRegistersUsableJwtHandlerFunc(t *testing.T) {
+	freshRuntime(t)
+
+	previousSecret := config.JwtConfig.Secret
+	config.JwtConfig.Secret = "test-secret-key"
+	t.Cleanup(func() { config.JwtConfig.Secret = previousSecret })
+
+	gin.SetMode(gin.TestMode)
+	InitMiddleware(gin.New())
+
+	h, ok := sdk.Runtime.GetHandlerFunc(JwtTokenCheck)
+	if !ok {
+		t.Fatal("GetHandlerFunc(JwtTokenCheck) reported ok=false after InitMiddleware ran")
+	}
+	if h == nil {
+		t.Fatal("GetHandlerFunc(JwtTokenCheck) reported ok=true but returned a nil handler")
+	}
+}
+
+// TestInitMiddlewareBuildsOneSharedJwtInstance locks down the fix for the
+// four-instances problem: GetAuthMiddleware must return the very instance
+// InitMiddleware built and handed to sdk.Runtime, not a lookalike built
+// separately by whichever caller asks first.
+func TestInitMiddlewareBuildsOneSharedJwtInstance(t *testing.T) {
+	freshRuntime(t)
+
+	previousSecret := config.JwtConfig.Secret
+	config.JwtConfig.Secret = "test-secret-key"
+	t.Cleanup(func() { config.JwtConfig.Secret = previousSecret })
+
+	gin.SetMode(gin.TestMode)
+	InitMiddleware(gin.New())
+
+	shared := GetAuthMiddleware()
+	if shared == nil {
+		t.Fatal("GetAuthMiddleware returned nil after InitMiddleware ran")
+	}
+	if shared != authMiddleware {
+		t.Error("GetAuthMiddleware did not return the package-level instance InitMiddleware built")
+	}
+}


### PR DESCRIPTION
> 依赖 [go-admin-core v2.5.0](https://github.com/go-admin-team/go-admin-core/releases/tag/v2.5.0)（已发布），`GetHandlerFunc` 随该版本发出。无 `replace`。

## 两个叠在一起的问题

**注册的是未绑定的方法表达式。** `common/middleware/init.go` 把 `JwtTokenCheck` 注册成 `(*jwt.GinJWTMiddleware).MiddlewareFunc`——那是 `func(*jwt.GinJWTMiddleware) gin.HandlerFunc`，不是 `gin.HandlerFunc`。core 的 `GetHandlerFunc` 做类型断言必然失败：**这个 key 注册了，同时又永远取不出来**。另外两个 key（`RoleCheck`/`PermissionCheck`）注册的是绑定闭包，是对的。

**四个模块各建一个实例。** `app/admin`、`app/jobs`、`app/other`、`app/demo` 的 `InitRouter` 各自调一次 `AuthInit()`。所以即使断言能过，Runtime 交回的也是「最后初始化的那个模块的实例」——由初始化顺序决定，而不是由设计决定。

## 改法

实例在 `InitMiddleware` 里构造一次，注册**绑定后的**闭包；四个模块改从 `GetAuthMiddleware()` 读回同一个。

访问器在未初始化时 `log.Fatal` 而不是返回 nil——一个没有 JWT 中间件的进程不该走到服务请求那一步。

全仓只有一处需要实例本身而非 handler：admin 的 `/login` 用 `LoginHandler`。三十余处 `MiddlewareFunc()` 调用点一字未动。

（`/refresh_token` 不在此列——它已在 issue #820 中因续期上限永远到不了而整个移除。）

## 行为变更

四实例 → 一实例。核实过 `AuthInit()` 只读 `config.ApplicationConfig.Mode` 与 `config.JwtConfig.{Timeout,Secret}`，没有任何随调用点变化的输入，四个实例本就是配置相同的独立对象——合并不改变行为，只是消除了「取回哪一个由初始化顺序决定」。

## 顺带

`init.go` 里本地重述的三个 key 常量改为直接引用 core 的 `runtime.JwtTokenCheck` 等。两处各写一遍同样的字符串，写错一个仍然编译通过，然后注册与查找落在两个不同的键上——与本批次 `PermissionKey` 那条同源。

## 验证

新增测试钉住两条性质：`GetHandlerFunc(JwtTokenCheck)` 必须报 `ok`，以及每个模块读回同一个实例。把注册改回方法表达式**仍然编译通过**，第一条变红——这正是它要钉住的失效。

真机（sqlite，18800 端口）：migrate 7 条全部应用；服务启动、路由注册完整；无 token 访问返 401；`/login` 走到 `Authenticator`（证明拿到的是真实可用的实例）；验证码接口正常。跑完停进程、还原数据库文件。

`go build ./...`、`go build -tags sqlite3 ./...`、`go test -tags sqlite3 ./...`、`make checksilent` 全绿。
