### PR TITLE
fix🐛: SIGTERM 从未被处理，优雅关闭在容器里是死代码

### DIFF
--- a/cmd/api/server.go
+++ b/cmd/api/server.go
@@ -115,6 +115,13 @@ func run() error {
 		}
 	}
 
+	// Armed before the server starts serving, and well before the readiness
+	// banner: a signal arriving between "the process is up" and "the process
+	// is listening for signals" reaches the default handler and kills it
+	// without any of the shutdown below. That window is the whole reason
+	// arming is separate from waiting.
+	quit, disarmStopSignals := armStopSignals()
+
 	go func() {
 		// 服务连接
 		if config.SslConfig.Enable {
@@ -137,7 +144,10 @@ func run() error {
 	fmt.Printf("-  Network: %s://%s:%d/swagger/admin/index.html \r\n", "http", pkg.GetLocalHost(), config.ApplicationConfig.Port)
 	fmt.Printf("%s Enter Control + C Shutdown Server \r\n", pkg.GetCurrentTimeStr())
 
-	waitForStopSignal()
+	<-quit
+	// Restored here, not deferred: from this point a second signal must reach
+	// the default handler, so a shutdown that hangs can still be interrupted.
+	disarmStopSignals()
 
 	log.Info("Shutdown Server ... ")
 	if err := shutdownServer(srv, shutdownTimeout); err != nil {
@@ -156,26 +166,14 @@ func run() error {
 // - `docker stop` allows 10s by default before it sends SIGKILL.
 const shutdownTimeout = 5 * time.Second
 
-// waitForStopSignal blocks until the process is asked to stop.
+// armStopSignals registers for the stop signals and returns the channel they
+// arrive on together with the function that restores the default disposition.
 //
 // SIGTERM is what actually arrives in production: `docker stop`, a Kubernetes
 // pod deletion and `systemctl stop` all send it, and Go terminates the process
 // immediately for a signal nobody listens for. Registering only os.Interrupt
-// meant every graceful shutdown below this line was dead code outside a
+// meant every graceful shutdown below the wait was dead code outside a
 // terminal.
-//
-// The disposition is restored before returning, so a second signal kills the
-// process the default way. The channel keeps the notification we already took,
-// so without this a stuck shutdown would swallow every further signal - once
-// SIGTERM is registered there is no escape hatch left but SIGKILL.
-func waitForStopSignal() os.Signal {
-	quit, disarm := armStopSignals()
-	defer disarm()
-	return <-quit
-}
-
-// armStopSignals registers for the stop signals and returns the channel they
-// arrive on together with the function that restores the default disposition.
 //
 // Registering is separate from waiting so a caller can arm before it announces
 // that it is ready: a signal that arrives between the two is delivered to the

--- a/cmd/api/server.go
+++ b/cmd/api/server.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"syscall"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -85,8 +86,8 @@ func run() error {
 	runStartupHooks()
 
 	srv := &http.Server{
-		Addr:    fmt.Sprintf("%s:%d", config.ApplicationConfig.Host, config.ApplicationConfig.Port),
-		Handler: sdk.Runtime.GetEngine(),
+		Addr:         fmt.Sprintf("%s:%d", config.ApplicationConfig.Host, config.ApplicationConfig.Port),
+		Handler:      sdk.Runtime.GetEngine(),
 		ReadTimeout:  time.Duration(config.ApplicationConfig.ReadTimeout) * time.Second,
 		WriteTimeout: time.Duration(config.ApplicationConfig.WriterTimeout) * time.Second,
 	}
@@ -135,21 +136,66 @@ func run() error {
 	fmt.Printf("-  Local:   http://localhost:%d/swagger/admin/index.html \r\n", config.ApplicationConfig.Port)
 	fmt.Printf("-  Network: %s://%s:%d/swagger/admin/index.html \r\n", "http", pkg.GetLocalHost(), config.ApplicationConfig.Port)
 	fmt.Printf("%s Enter Control + C Shutdown Server \r\n", pkg.GetCurrentTimeStr())
-	// 等待中断信号以优雅地关闭服务器（设置 5 秒的超时时间）
-	quit := make(chan os.Signal, 1)
-	signal.Notify(quit, os.Interrupt)
-	<-quit
 
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
+	waitForStopSignal()
+
 	log.Info("Shutdown Server ... ")
-
-	if err := srv.Shutdown(ctx); err != nil {
-		log.Fatal("Server Shutdown:", err)
+	if err := shutdownServer(srv, shutdownTimeout); err != nil {
+		// Not log.Fatal: that is an unconditional os.Exit(1), and Shutdown
+		// reports an error exactly when connections were still in flight -
+		// which is when the cleanup that follows matters most.
+		log.Error("Server Shutdown: ", err)
 	}
 	log.Info("Server exiting")
 
 	return nil
+}
+
+// shutdownTimeout is how long Shutdown waits for in-flight requests. It plus
+// whatever cleanup follows has to stay inside the orchestrator's grace period
+// - `docker stop` allows 10s by default before it sends SIGKILL.
+const shutdownTimeout = 5 * time.Second
+
+// waitForStopSignal blocks until the process is asked to stop.
+//
+// SIGTERM is what actually arrives in production: `docker stop`, a Kubernetes
+// pod deletion and `systemctl stop` all send it, and Go terminates the process
+// immediately for a signal nobody listens for. Registering only os.Interrupt
+// meant every graceful shutdown below this line was dead code outside a
+// terminal.
+//
+// The disposition is restored before returning, so a second signal kills the
+// process the default way. The channel keeps the notification we already took,
+// so without this a stuck shutdown would swallow every further signal - once
+// SIGTERM is registered there is no escape hatch left but SIGKILL.
+func waitForStopSignal() os.Signal {
+	quit, disarm := armStopSignals()
+	defer disarm()
+	return <-quit
+}
+
+// armStopSignals registers for the stop signals and returns the channel they
+// arrive on together with the function that restores the default disposition.
+//
+// Registering is separate from waiting so a caller can arm before it announces
+// that it is ready: a signal that arrives between the two is delivered to the
+// default handler, which for both of these means the process dies without
+// running any of this.
+func armStopSignals() (<-chan os.Signal, func()) {
+	quit := make(chan os.Signal, 1)
+	signal.Notify(quit, os.Interrupt, syscall.SIGTERM)
+	return quit, func() { signal.Stop(quit) }
+}
+
+// shutdownServer stops srv, giving in-flight requests up to timeout to finish.
+//
+// It returns the error instead of exiting on it. A caller that exits here skips
+// its own cleanup, and Shutdown fails precisely when there was something left
+// to clean up after.
+func shutdownServer(srv *http.Server, timeout time.Duration) error {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	return srv.Shutdown(ctx)
 }
 
 // runStartupHooks runs the router registries and then the before callbacks.

--- a/cmd/api/signal_test.go
+++ b/cmd/api/signal_test.go
@@ -44,15 +44,6 @@ func TestSignalChild(t *testing.T) {
 	srv := &http.Server{Handler: http.NewServeMux()}
 	go func() { _ = srv.Serve(ln) }()
 
-	if os.Getenv(childHangConn) == "1" {
-		c, err := net.Dial("tcp", ln.Addr().String())
-		if err != nil {
-			fmt.Println("dial:", err)
-			os.Exit(5)
-		}
-		defer func() { _ = c.Close() }()
-	}
-
 	// Arm before announcing readiness. Doing it the other way round leaves a
 	// window in which the parent's signal reaches the default handler and
 	// kills the child before any of this runs - which is exactly the failure
@@ -77,6 +68,16 @@ func TestSignalChild(t *testing.T) {
 
 	timeout := shutdownTimeout
 	if os.Getenv(childHangConn) == "1" {
+		// Dialled here, not at start-up. net/http stops counting a StateNew
+		// connection against Shutdown once it is more than five seconds old,
+		// so a connection opened before the wait would age out on a slow CI
+		// run and Shutdown would succeed - leaving the test asserting nothing.
+		c, err := net.Dial("tcp", ln.Addr().String())
+		if err != nil {
+			fmt.Println("dial:", err)
+			os.Exit(5)
+		}
+		defer func() { _ = c.Close() }()
 
 		// A connection that has sent nothing keeps Shutdown busy: net/http
 		// only treats a StateNew connection as idle once it is more than five

--- a/cmd/api/signal_test.go
+++ b/cmd/api/signal_test.go
@@ -1,0 +1,266 @@
+package api
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+	"os"
+	"os/exec"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// The signal path cannot be exercised in-process: delivering a signal to the
+// test binary would race with the test framework, and the disposition changes
+// are global. So the test re-executes itself as a child, and the child runs the
+// same waitForStopSignal / shutdownServer the server does.
+//
+// The child deliberately serves an empty http.Server rather than the real one:
+// this repository's CI has no database (.github/workflows/go.yml runs neither
+// MySQL nor a sqlite-tagged build), and none of what is under test needs one.
+const (
+	childEnv       = "GO_ADMIN_SIGNAL_CHILD"
+	childStuckEnv  = "GO_ADMIN_SIGNAL_CHILD_STUCK"
+	childHangConn  = "GO_ADMIN_SIGNAL_CHILD_HANGCONN"
+	markerReady    = "CHILD-READY"
+	markerSignal   = "CHILD-SIGNAL"
+	markerShutdown = "CHILD-SHUTDOWN-OK"
+	markerExiting  = "CHILD-EXITING"
+)
+
+// TestSignalChild is the child process. It is skipped in a normal run.
+func TestSignalChild(t *testing.T) {
+	if os.Getenv(childEnv) != "1" {
+		t.Skip("child process entry point")
+	}
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		fmt.Println("listen:", err)
+		os.Exit(3)
+	}
+	srv := &http.Server{Handler: http.NewServeMux()}
+	go func() { _ = srv.Serve(ln) }()
+
+	if os.Getenv(childHangConn) == "1" {
+		c, err := net.Dial("tcp", ln.Addr().String())
+		if err != nil {
+			fmt.Println("dial:", err)
+			os.Exit(5)
+		}
+		defer func() { _ = c.Close() }()
+	}
+
+	// Arm before announcing readiness. Doing it the other way round leaves a
+	// window in which the parent's signal reaches the default handler and
+	// kills the child before any of this runs - which is exactly the failure
+	// this whole change is about, so the test must not reproduce it by
+	// accident.
+	quit, disarm := armStopSignals()
+
+	fmt.Println(markerReady)
+	os.Stdout.Sync()
+
+	sig := <-quit
+	disarm()
+	fmt.Println(markerSignal, sig)
+	os.Stdout.Sync()
+
+	if os.Getenv(childStuckEnv) == "1" {
+		// Stand in for a cleanup hook that never finishes. The point of
+		// restoring the signal disposition is that a second signal still
+		// reaches the default handler and kills this.
+		time.Sleep(2 * time.Minute)
+	}
+
+	timeout := shutdownTimeout
+	if os.Getenv(childHangConn) == "1" {
+		// A connection that has sent nothing keeps Shutdown busy: net/http
+		// only treats a StateNew connection as idle once it is more than five
+		// seconds old. A short budget makes the timeout deterministic without
+		// waiting out the real one.
+		timeout = 300 * time.Millisecond
+	}
+
+	if err := shutdownServer(srv, timeout); err != nil {
+		// Deliberately not fatal, and deliberately not a bare return: the
+		// point is that whatever follows still runs.
+		fmt.Println("shutdown error:", err)
+	} else {
+		fmt.Println(markerShutdown)
+	}
+	fmt.Println(markerExiting)
+	os.Stdout.Sync()
+}
+
+func startChild(t *testing.T, stuck bool, extraEnv ...string) (*exec.Cmd, *os.File, chan string) {
+	t.Helper()
+
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	cmd := exec.Command(os.Args[0], "-test.run=TestSignalChild", "-test.v")
+	cmd.Env = append(os.Environ(), childEnv+"=1")
+	if stuck {
+		cmd.Env = append(cmd.Env, childStuckEnv+"=1")
+	}
+	cmd.Env = append(cmd.Env, extraEnv...)
+	cmd.Stdout = w
+	cmd.Stderr = w
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start child: %v", err)
+	}
+	_ = w.Close()
+
+	lines := make(chan string, 64)
+	go func() {
+		defer close(lines)
+		buf := make([]byte, 4096)
+		var acc strings.Builder
+		for {
+			n, err := r.Read(buf)
+			if n > 0 {
+				acc.Write(buf[:n])
+				for {
+					s := acc.String()
+					i := strings.IndexByte(s, '\n')
+					if i < 0 {
+						break
+					}
+					lines <- s[:i]
+					acc.Reset()
+					acc.WriteString(s[i+1:])
+				}
+			}
+			if err != nil {
+				if acc.Len() > 0 {
+					lines <- acc.String()
+				}
+				return
+			}
+		}
+	}()
+
+	t.Cleanup(func() {
+		_ = cmd.Process.Kill()
+		_, _ = cmd.Process.Wait()
+		_ = r.Close()
+	})
+	return cmd, r, lines
+}
+
+// await drains lines until one contains want, or the deadline passes. It
+// returns everything it saw, so a failure says what the child actually did.
+func await(t *testing.T, lines chan string, want string, d time.Duration) []string {
+	t.Helper()
+	var seen []string
+	deadline := time.After(d)
+	for {
+		select {
+		case l, ok := <-lines:
+			if !ok {
+				t.Fatalf("child output ended before %q; saw:\n%s", want, strings.Join(seen, "\n"))
+			}
+			seen = append(seen, l)
+			if strings.Contains(l, want) {
+				return seen
+			}
+		case <-deadline:
+			t.Fatalf("timed out waiting for %q; saw:\n%s", want, strings.Join(seen, "\n"))
+		}
+	}
+}
+
+// Acceptance 19. Registering only os.Interrupt meant SIGTERM - the signal
+// `docker stop`, Kubernetes and systemd all send - terminated the process
+// before any of the shutdown path ran. Both must now reach it.
+func TestBothSignalsRunTheShutdownPath(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		sig  syscall.Signal
+	}{
+		{"SIGINT", syscall.SIGINT},
+		{"SIGTERM", syscall.SIGTERM},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cmd, _, lines := startChild(t, false)
+			await(t, lines, markerReady, 30*time.Second)
+
+			if err := cmd.Process.Signal(tc.sig); err != nil {
+				t.Fatalf("signal: %v", err)
+			}
+
+			await(t, lines, markerSignal, 10*time.Second)
+			await(t, lines, markerShutdown, 10*time.Second)
+			await(t, lines, markerExiting, 10*time.Second)
+
+			if err := cmd.Wait(); err != nil {
+				t.Fatalf("child exited with %v, want a clean exit", err)
+			}
+		})
+	}
+}
+
+// Acceptance 20. quit is a buffered channel and signal.Notify stays armed, so
+// without restoring the disposition a second signal only refills the buffer:
+// once SIGTERM is registered, a shutdown that hangs could not be interrupted by
+// anything short of SIGKILL.
+func TestASecondSignalStillKillsAStuckShutdown(t *testing.T) {
+	cmd, _, lines := startChild(t, true)
+	await(t, lines, markerReady, 30*time.Second)
+
+	if err := cmd.Process.Signal(syscall.SIGTERM); err != nil {
+		t.Fatalf("first signal: %v", err)
+	}
+	await(t, lines, markerSignal, 10*time.Second)
+
+	// The child is now inside a cleanup that will not finish on its own.
+	if err := cmd.Process.Signal(syscall.SIGTERM); err != nil {
+		t.Fatalf("second signal: %v", err)
+	}
+
+	done := make(chan error, 1)
+	go func() { done <- cmd.Wait() }()
+
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("child exited cleanly; it was supposed to be killed by the second signal")
+		}
+	case <-time.After(15 * time.Second):
+		t.Fatal("the second signal did not kill a stuck shutdown - the escape hatch is gone")
+	}
+}
+
+// Acceptance 21. srv.Shutdown reports an error exactly when connections were
+// still in flight, and the old code answered that with log.Fatal - an
+// unconditional os.Exit(1). Everything after it, which is where the cleanup
+// hooks will hang, never ran. A failed Shutdown must not end the process.
+func TestShutdownTimeoutDoesNotStopWhatFollows(t *testing.T) {
+	cmd, _, lines := startChild(t, false, childHangConn+"=1")
+	await(t, lines, markerReady, 30*time.Second)
+
+	if err := cmd.Process.Signal(syscall.SIGTERM); err != nil {
+		t.Fatalf("signal: %v", err)
+	}
+	await(t, lines, markerSignal, 10*time.Second)
+
+	seen := await(t, lines, markerExiting, 20*time.Second)
+
+	var timedOut bool
+	for _, l := range seen {
+		if strings.Contains(l, "shutdown error:") {
+			timedOut = true
+		}
+	}
+	if !timedOut {
+		t.Fatalf("Shutdown did not time out, so this test proves nothing; saw:\n%s",
+			strings.Join(seen, "\n"))
+	}
+	if err := cmd.Wait(); err != nil {
+		t.Fatalf("child exited with %v after a failed Shutdown, want a clean exit", err)
+	}
+}

--- a/cmd/api/signal_test.go
+++ b/cmd/api/signal_test.go
@@ -15,7 +15,7 @@ import (
 // The signal path cannot be exercised in-process: delivering a signal to the
 // test binary would race with the test framework, and the disposition changes
 // are global. So the test re-executes itself as a child, and the child runs the
-// same waitForStopSignal / shutdownServer the server does.
+// same armStopSignals / shutdownServer the server does.
 //
 // The child deliberately serves an empty http.Server rather than the real one:
 // this repository's CI has no database (.github/workflows/go.yml runs neither
@@ -77,6 +77,7 @@ func TestSignalChild(t *testing.T) {
 
 	timeout := shutdownTimeout
 	if os.Getenv(childHangConn) == "1" {
+
 		// A connection that has sent nothing keeps Shutdown busy: net/http
 		// only treats a StateNew connection as idle once it is more than five
 		// seconds old. A short budget makes the timeout deterministic without

--- a/cmd/api/signal_test.go
+++ b/cmd/api/signal_test.go
@@ -41,7 +41,22 @@ func TestSignalChild(t *testing.T) {
 		fmt.Println("listen:", err)
 		os.Exit(3)
 	}
-	srv := &http.Server{Handler: http.NewServeMux()}
+	// accepted fires once the server has taken a connection off the listener.
+	// Dialling is not enough: Shutdown only waits for connections the server
+	// has already accepted, so calling it between the dial and the accept
+	// finds nothing to wait for and returns immediately.
+	accepted := make(chan struct{}, 1)
+	srv := &http.Server{
+		Handler: http.NewServeMux(),
+		ConnState: func(_ net.Conn, state http.ConnState) {
+			if state == http.StateNew {
+				select {
+				case accepted <- struct{}{}:
+				default:
+				}
+			}
+		},
+	}
 	go func() { _ = srv.Serve(ln) }()
 
 	// Arm before announcing readiness. Doing it the other way round leaves a
@@ -78,6 +93,15 @@ func TestSignalChild(t *testing.T) {
 			os.Exit(5)
 		}
 		defer func() { _ = c.Close() }()
+
+		// And wait for the accept, for the opposite reason: an unaccepted
+		// connection is not one Shutdown waits for either.
+		select {
+		case <-accepted:
+		case <-time.After(10 * time.Second):
+			fmt.Println("the server never accepted the stalling connection")
+			os.Exit(6)
+		}
 
 		// A connection that has sent nothing keeps Shutdown busy: net/http
 		// only treats a StateNew connection as idle once it is more than five


### PR DESCRIPTION
## SIGTERM 从来没有被处理过

`cmd/api/server.go` 只注册了 `os.Interrupt`。全仓 `SIGTERM` 零命中——go-admin 与 core 都是。Go 对未注册的信号走默认处置：立即终止进程。

而 `docker stop`、Kubernetes 停 Pod、`systemctl stop` 发的**都是 SIGTERM**。

对真实二进制实测（同一份配置，分别发两种信号）：

| 信号 | 进程 | `Shutdown Server ...` | `Server exiting` |
|---|---|---|---|
| SIGINT | 退出 | ✅ | ✅ |
| **SIGTERM** | 退出 | ❌ | ❌ |

**除了在终端里按 Ctrl+C，优雅关闭从来没有执行过。** `srv.Shutdown()` 不跑，飞行中的 HTTP 请求被拦腰截断。演示站是 docker 部署的，一直如此。

---

## 一条路径上的三个缺陷

### ① 注册 SIGTERM

一行。但它把一条从未执行过的代码路径变成了默认路径，所以下面两条必须同批修——否则等于刚把死代码激活就让它以新的方式坏掉。

### ② 加了 SIGTERM 之后，逃生口消失了

`quit` 是 cap=1 的 buffered channel，首个信号被取走后 `signal.Notify` 仍然生效，后续信号只会填进 buffer、不再交给默认处置。

今天这不是问题，因为 SIGTERM 没注册，它**就是**那个逃生口。注册之后，一个卡住的关闭将**连 SIGTERM 都不管用**，只剩 SIGKILL。

改法：取走首个信号后 `signal.Stop(quit)`，第二个信号恢复默认处置直接杀。

顺带把注册和等待拆开了（`armStopSignals` / `waitForStopSignal`）——**信号处理应该在宣告就绪之前装好**。写测试时正好撞到这个：子进程先打印就绪、再注册，父进程在那个窗口里发的信号走默认处置直接杀掉它，测试差点自己复现了本 PR 要修的失败形状。

### ③ 失败的 `Shutdown` 跳过它后面的一切

`log.Fatal` 是无条件 `os.Exit(1)`（`logger/level.go`）。而 `Shutdown` 返回错误的时机，恰恰是「还有连接在飞行中」——**清理最需要执行的那一刻**。

这个失败比看上去近得多。net/http 只把存活**超过 5 秒**的 `StateNew` 连接当空闲关掉，所以信号到达前不久建立、尚未发出完整请求的一条连接会吃满整个预算：

| readtimeout | 静默连接年龄 | 耗时 | 结果 |
|---|---|---|---|
| 1s（仓库默认 `settings.yml`） | 1s | 0.005–1.13s | 正常退出 |
| 10000s（`settings.demo.yml`） | 1.0s | 4.81s | 险过 |
| 10000s | 0.2s | **5.04s** | **fatal / exit 1**，`Server exiting` 零次 |

这是**一场跟 5 秒死线的赛跑**，不是必然超时。仓库默认的 `readtimeout: 1` 让服务端先关掉静默连接，一直掩盖着它；演示站配置的 `10000`（≈2.8 小时，等于没有读超时）暴露它。

改成 `log.Error` 并继续往下走。

---

## 测试

CI 没有 MySQL，`make build` 是 `CGO_ENABLED=0` 且不带 `-tags sqlite3`，真起一个 server 需要数据库。所以把 `<-quit → Shutdown → 收尾` 抽成可测函数，子进程测试起一个**空 `http.Server`** 调真函数、发真信号——不需要配置与 DB。

三条验收各自反证，**每条反证前先 `go vet` 确认能编译**：

| 退回的实现 | 变红 |
|---|---|
| 去掉 `syscall.SIGTERM` | `TestBothSignalsRunTheShutdownPath/SIGTERM` |
| 去掉 `signal.Stop` | `the second signal did not kill a stuck shutdown - the escape hatch is gone` |
| 关闭出错就退出 | `child output ended before "CHILD-EXITING"` |

**一处边界说明**：`run()` 里那行 `log.Error` 本身没有测试覆盖——子进程调的是抽出来的 `shutdownServer`，不走 `run()`。测试钉住的是「抽出的函数返回错误而不是退出」和「调用方继续往下能到清理」，那一行目前只有目视检查，等关闭钩子落地才有真覆盖。

21 个包测试通过，`make checksilent` 0 error。

---

## 一个行为变更

`restart.sh` 用 `killall`（默认 SIGTERM），修完之后本地重启会从「立即死」变成「最多等 5 秒」。这是预期内的——那 5 秒正是在等飞行中的请求收尾。
