### PR TITLE
fix🐛: 开了数据权限就登不进去——/getinfo 拿不到它要的 DataPermission

### DIFF
--- a/app/admin/apis/sys_user.go
+++ b/app/admin/apis/sys_user.go
@@ -444,7 +444,6 @@ func (e SysUser) GetInfo(c *gin.Context) {
 		e.Error(500, err, err.Error())
 		return
 	}
-	p := actions.GetPermissionFromContext(c)
 	var roles = make([]string, 1)
 	roles[0] = user.GetRoleName(c)
 	var permissions = make([]string, 1)
@@ -464,7 +463,14 @@ func (e SysUser) GetInfo(c *gin.Context) {
 	}
 	sysUser := models.SysUser{}
 	req.Id = user.GetUserId(c)
-	err = s.Get(&req, p, &sysUser)
+	// Unscoped on purpose: the id is the caller's own, taken from the token.
+	// This used to go through Get with whatever GetPermissionFromContext
+	// returned - and this route installs no PermissionAction, so that was the
+	// zero value. An unset scope is not a recognised one, so once unknown
+	// scopes started failing closed rather than silently matching everything,
+	// every login on a deployment with enabledp: true ended here with a 401
+	// and the browser went straight back to the login page.
+	err = s.GetSelf(&req, &sysUser)
 	if err != nil {
 		e.Error(http.StatusUnauthorized, err, "登录失败")
 		return

--- a/app/admin/router/sys_api.go
+++ b/app/admin/router/sys_api.go
@@ -5,6 +5,7 @@ import (
 	jwt "github.com/go-admin-team/go-admin-core/v2/jwtauth"
 
 	"go-admin/app/admin/apis"
+	"go-admin/common/actions"
 	"go-admin/common/middleware"
 )
 
@@ -15,7 +16,10 @@ func init() {
 // registerSysApiRouter
 func registerSysApiRouter(v1 *gin.RouterGroup, authMiddleware *jwt.GinJWTMiddleware) {
 	api := apis.SysApi{}
-	r := v1.Group("/sys-api").Use(authMiddleware.MiddlewareFunc()).Use(middleware.AuthCheckRole())
+	// PermissionAction is not optional here: all three handlers below read the
+	// data permission out of the context, and without it they read the zero
+	// value - an unset scope, which Permission now fails closed on.
+	r := v1.Group("/sys-api").Use(authMiddleware.MiddlewareFunc()).Use(middleware.AuthCheckRole()).Use(actions.PermissionAction())
 	{
 		r.GET("", api.GetPage)
 		r.GET("/:id", api.Get)

--- a/app/admin/service/sys_user.go
+++ b/app/admin/service/sys_user.go
@@ -38,6 +38,30 @@ func (e *SysUser) GetPage(c *dto.SysUserGetPageReq, p *actions.DataPermission, l
 	return nil
 }
 
+// GetSelf 获取调用者自己的 SysUser 对象，不套数据权限
+//
+// The data scope answers "whose rows may this user see"; the caller here is
+// reading their own, and the id comes from the token, so there is nothing left
+// for a scope to restrict. Applying one is not a stricter version of this
+// query - it is a broken one. DataScopeSelf matches on create_by, and a user
+// account is created by whoever added it, so a scoped self-read would fail for
+// every user who did not create their own account.
+//
+// GetProfile has always read the same row this way, with no scope at all.
+func (e *SysUser) GetSelf(d *dto.SysUserById, model *models.SysUser) error {
+	err := e.Orm.First(model, d.GetId()).Error
+	if err != nil && errors.Is(err, gorm.ErrRecordNotFound) {
+		err = errors.New("查看对象不存在或无权查看")
+		e.Log.Errorf("db error: %s", err)
+		return err
+	}
+	if err != nil {
+		e.Log.Errorf("db error: %s", err)
+		return err
+	}
+	return nil
+}
+
 // Get 获取SysUser对象
 func (e *SysUser) Get(d *dto.SysUserById, p *actions.DataPermission, model *models.SysUser) error {
 	var data models.SysUser


### PR DESCRIPTION
## 现象

开了数据权限（`enabledp: true`）的部署**登不进去**。登录本身是成功的——`sys_login_log`
里记着「登录成功」——紧接着 `/api/v1/getinfo` 返回 401，浏览器被弹回登录页。

```json
{"code": 401, "msg": "登录失败", "status": "error", "data": null}
```

服务端日志里那条 SQL 是判据：

```sql
SELECT * FROM sys_user WHERE sys_user.user_id = 1 AND 1 = 0 AND deleted_at = 0
```

`1 = 0` 来自数据权限。

## 根因

`GetInfo` 用 `GetPermissionFromContext(c)` 取数据权限，而它所在的路由组
**只挂了 JWT，没有 `PermissionAction()`**：

```go
v1auth := v1.Group("").Use(authMiddleware.MiddlewareFunc())   // ← 没有 PermissionAction
{
    v1auth.GET("/getinfo", api.GetInfo)
}
```

于是从来没有人往 context 里放过权限，取回来的是**零值**，`DataScope` 是空字符串。
空字符串不属于那五个合法范围之一，而未知范围现在是 **fail closed**（匹配零行）
而不是从前那样悄悄放行——这条路由过去是**靠巧合活着的**。

只在开了数据权限的部署上发作：仓库默认 `enabledp: false`，`Permission` 第一行就
`return db`。**这就是本地全量测试和 CI 都绿、而演示站登不进去的原因。**

## 两处修法

**`/getinfo` —— 去掉数据权限。**
它读的是调用者自己的行，id 来自 token。数据范围约束的是「能看谁的行」，
这里没有可约束的对象。套上范围会引入新的故障：`DataScopeSelf` 匹配 `create_by`，
而账号通常由管理员创建，于是每一个非自建账号的用户都会登不进去。

改走不套权限的 `GetSelf`——同文件的 `GetProfile` 一直就是这么读同一行的。

**`/sys-api` —— 补上中间件。**
它的三个 handler 确实在读权限，而且确实在列、改别人的行，该受约束。
中间件是纯粹漏了（那个文件连 `common/actions` 都没 import）。

## 排查范围

把「handler 读数据权限」与「它注册所在的组是否挂了 `PermissionAction`」逐条比对，
命中 4 个端点：

| 端点 | 后果 |
|---|---|
| `GET /api/v1/getinfo` | **登不进去** |
| `GET /api/v1/sys-api` | 接口管理页空白 |
| `GET /api/v1/sys-api/:id` | 详情取不到 |
| `PUT /api/v1/sys-api/:id` | 改不动 |

同一份比对在本 PR 之前报 4 条，之后报 0 条。

## 对现有数据的影响

线上数据核实过：唯一角色 `admin` 的 `data_scope = 1`（全部数据权限），
`sys_api` 126 行的 `create_by` 全部是 0。给 `/sys-api` 补上中间件之后，
`DataScopeAll` 分支直接 `return db`，列表照常。

## 没有测试

两条路径都要有 `sys_user` / `sys_role` 数据的 `*gorm.DB` 才能走到出问题那一行，
而本仓 CI 没有数据库（`make build` 是 `CGO_ENABLED=0` 且不带 sqlite tag）。

可自动化的是这个错误的形状：「handler 读权限但路由没挂中间件」
应当成为 `tools/checksilent` 的一条规则，单开 PR 处理，不阻塞本次修复。

## 验证

- `go build ./...` / `go vet ./...` / `go test ./...` 退出码均为 0，21 个包通过
- 上述比对：修复前 4 条，修复后 0 条

