### PR TITLE
test✅: 补上 #892 修复中没有断言的那一半

### DIFF
--- a/common/storage/setup_gen_test.go
+++ b/common/storage/setup_gen_test.go
@@ -3,7 +3,9 @@ package storage
 import (
 	"testing"
 
+	"github.com/go-admin-team/go-admin-core/v2/sdk"
 	"github.com/go-admin-team/go-admin-core/v2/sdk/config"
+	"github.com/go-admin-team/go-admin-core/v2/sdk/runtime"
 )
 
 // Issue #892: a configuration reload replaces the queue adapter and the
@@ -16,8 +18,21 @@ import (
 // queue for it to notice. Setup is what config re-runs on every change, so
 // calling it twice is what a reload does to this package.
 func TestSetupBumpsTheQueueGenerationOnEveryReload(t *testing.T) {
+	// Setup writes the process-wide sdk.Runtime - the cache and queue adapters -
+	// and this package's own record of what it installed. Restoring all of it
+	// keeps the test from deciding what a later test in this binary sees,
+	// which is the same isolation cmd/api's freshRuntime provides.
 	prevQ, prevC := config.QueueConfig, config.CacheConfig
-	t.Cleanup(func() { config.QueueConfig, config.CacheConfig = prevQ, prevC })
+	prevRuntime := sdk.Runtime
+	prevInstalled, prevGen := installed, installedGen
+	t.Cleanup(func() {
+		config.QueueConfig, config.CacheConfig = prevQ, prevC
+		sdk.Runtime = prevRuntime
+		queueMu.Lock()
+		installed, installedGen = prevInstalled, prevGen
+		queueMu.Unlock()
+	})
+	sdk.Runtime = runtime.NewConfig()
 
 	config.CacheConfig = &config.Cache{Memory: struct{}{}}
 	config.QueueConfig = &config.Queue{Memory: &config.QueueMemory{PoolSize: 10}}

--- a/common/storage/setup_gen_test.go
+++ b/common/storage/setup_gen_test.go
@@ -1,0 +1,38 @@
+package storage
+
+import (
+	"testing"
+
+	"github.com/go-admin-team/go-admin-core/v2/sdk/config"
+)
+
+// Issue #892: a configuration reload replaces the queue adapter and the
+// consumers registered against the previous one are attached to a queue nobody
+// publishes to any more.
+//
+// The fix has two halves. attachQueueConsumers gives a new queue its own
+// consumers and the same queue none, which cmd/api covers against a queue the
+// test controls. This is the other half: that a reload actually produces a new
+// queue for it to notice. Setup is what config re-runs on every change, so
+// calling it twice is what a reload does to this package.
+func TestSetupBumpsTheQueueGenerationOnEveryReload(t *testing.T) {
+	prevQ, prevC := config.QueueConfig, config.CacheConfig
+	t.Cleanup(func() { config.QueueConfig, config.CacheConfig = prevQ, prevC })
+
+	config.CacheConfig = &config.Cache{Memory: struct{}{}}
+	config.QueueConfig = &config.Queue{Memory: &config.QueueMemory{PoolSize: 10}}
+
+	before := QueueGeneration()
+	Setup()
+	first := QueueGeneration()
+	Setup()
+	second := QueueGeneration()
+
+	t.Logf("before=%d first=%d second=%d", before, first, second)
+	if first == before {
+		t.Fatal("the first Setup did not install a queue")
+	}
+	if second == first {
+		t.Fatal("a second Setup - which is what a configuration reload does - did not install a new one")
+	}
+}


### PR DESCRIPTION
`Closes #892`

## 缺的是哪一半

#892 的修复在 #906 里，分两半：

1. **`attachQueueConsumers` 对同一队列幂等、对新队列重新注册**
   —— `cmd/api` 已有测试，靠手工传入代际号驱动
2. **一次重载真的会产生新的代际** —— 这一半**没有任何断言**

第 2 条只在两个函数「读起来会碰头」这个判断上，没有测试。本 PR 补上它。

`Setup` 正是配置每次变更时被重跑的那个函数，所以调用两次就是这个包眼中的一次重载。
代际走 0 → 1 → 2。

## 反证

去掉 `setupQueue` 里的 `installedGen++`，编译通过、测试变红：

```
the first Setup did not install a queue
```

—— 代际不动的话，「已安装」和「从未安装」在外部是分不出来的。

## 为什么值得单开一条

两半都被断言之后，「#892 已修」这个结论才落在测试上，而不是落在阅读上。
