### PR TITLE
fix🐛: 热重载期间生产者被指向已关闭的队列

### DIFF
--- a/common/storage/initialize.go
+++ b/common/storage/initialize.go
@@ -71,22 +71,32 @@ func setupQueue() {
 	queueMu.Lock()
 	defer queueMu.Unlock()
 
+	queueAdapter, err := config.QueueConfig.Setup()
+	if err != nil {
+		log.Fatalf("queue setup error, %s\n", err.Error())
+	}
+
+	previous := installed
+	sdk.Runtime.SetQueueAdapter(queueAdapter)
+	installed = queueAdapter
+	installedGen++
+
+	// The previous adapter goes down after the new one is installed, not
+	// before. Shutdown waits for its consumers to deliver what it still holds,
+	// and for that whole wait the runtime would otherwise be handing producers
+	// a queue that has stopped accepting: every Append in the window comes back
+	// ErrQueueClosed, and both call sites in common/middleware log it. Swapping
+	// first leaves no such window - a producer gets the new queue or the old
+	// one, and both work.
+	//
 	// Only an adapter this package installed. GetQueueAdapter never returns
 	// nil - with nothing configured the runtime falls back to its own memory
 	// queue and wraps that - so the `if q := GetQueueAdapter(); q != nil` this
 	// replaces was always true, and shut down the fallback queue on the very
 	// first start, before anything had used it.
-	if installed != nil {
-		installed.Shutdown()
+	if previous != nil {
+		previous.Shutdown()
 	}
-
-	queueAdapter, err := config.QueueConfig.Setup()
-	if err != nil {
-		log.Fatalf("queue setup error, %s\n", err.Error())
-	}
-	sdk.Runtime.SetQueueAdapter(queueAdapter)
-	installed = queueAdapter
-	installedGen++
 
 	// Deliberately not started here. Run has to come after the consumers have
 	// registered: the contract implementations refuse a registration once the

--- a/common/storage/queue_swap_test.go
+++ b/common/storage/queue_swap_test.go
@@ -1,0 +1,108 @@
+package storage
+
+import (
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/go-admin-team/go-admin-core/v2/sdk"
+	"github.com/go-admin-team/go-admin-core/v2/sdk/config"
+	"github.com/go-admin-team/go-admin-core/v2/sdk/runtime"
+	corestorage "github.com/go-admin-team/go-admin-core/v2/storage"
+	"github.com/go-admin-team/go-admin-core/v2/storage/queue"
+)
+
+func swapMsg() corestorage.Messager {
+	m := new(queue.Message)
+	m.SetStream("t")
+	m.SetValues(map[string]interface{}{"a": "b"})
+	return m
+}
+
+// A reload must never leave producers holding a queue that has stopped
+// accepting.
+//
+// Shutdown waits for its consumers to deliver what the queue still holds. Taking
+// the old adapter down before installing the new one meant the runtime pointed
+// at a closed queue for that entire wait: every Append in the window came back
+// ErrQueueClosed, and both call sites in common/middleware log it at error
+// level. Installing first leaves no window - a producer gets the new queue or
+// the old one, and both accept.
+//
+// The difference is only visible during that wait, which is why the test holds
+// a consumer rather than checking the state after Setup has returned: by then
+// the two orders look identical.
+func TestAReloadNeverPointsProducersAtAClosedQueue(t *testing.T) {
+	prevQ, prevC := config.QueueConfig, config.CacheConfig
+	prevRuntime := sdk.Runtime
+	prevInstalled, prevGen := installed, installedGen
+	t.Cleanup(func() {
+		config.QueueConfig, config.CacheConfig = prevQ, prevC
+		sdk.Runtime = prevRuntime
+		queueMu.Lock()
+		installed, installedGen = prevInstalled, prevGen
+		queueMu.Unlock()
+	})
+	sdk.Runtime = runtime.NewConfig()
+	config.CacheConfig = &config.Cache{Memory: struct{}{}}
+	config.QueueConfig = &config.Queue{Memory: &config.QueueMemory{PoolSize: 64}}
+
+	Setup()
+
+	// A consumer that will not finish until this test lets it, so the reload's
+	// Shutdown has something to wait for.
+	release := make(chan struct{})
+	first := sdk.Runtime.GetQueuePrefix("")
+	first.Register("t", func(corestorage.Messager) error {
+		<-release
+		return nil
+	})
+	go first.Run()
+	for i := 0; i < 4; i++ {
+		if err := first.Append(swapMsg()); err != nil {
+			t.Fatalf("seed append %d: %v", i, err)
+		}
+	}
+	time.Sleep(100 * time.Millisecond) // let the consumer pick one up and block
+
+	reloaded := make(chan struct{})
+	go func() { Setup(); close(reloaded) }()
+
+	// Publish continuously while the reload is in progress.
+	var refused atomic.Int64
+	var attempts atomic.Int64
+	stop := make(chan struct{})
+	go func() {
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			attempts.Add(1)
+			if err := sdk.Runtime.GetQueuePrefix("").Append(swapMsg()); errors.Is(err, corestorage.ErrQueueClosed) {
+				refused.Add(1)
+			}
+			time.Sleep(time.Millisecond)
+		}
+	}()
+
+	time.Sleep(200 * time.Millisecond) // the reload is now inside Shutdown's wait
+	close(release)
+
+	select {
+	case <-reloaded:
+	case <-time.After(10 * time.Second):
+		t.Fatal("the reload never finished")
+	}
+	close(stop)
+
+	if attempts.Load() == 0 {
+		t.Fatal("nothing was published during the reload; the test proves nothing")
+	}
+	if n := refused.Load(); n > 0 {
+		t.Errorf("%d of %d publishes during the reload were refused: producers were pointed at the closed queue",
+			n, attempts.Load())
+	}
+}

--- a/common/storage/queue_swap_test.go
+++ b/common/storage/queue_swap_test.go
@@ -2,6 +2,7 @@ package storage
 
 import (
 	"errors"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -12,6 +13,11 @@ import (
 	corestorage "github.com/go-admin-team/go-admin-core/v2/storage"
 	"github.com/go-admin-team/go-admin-core/v2/storage/queue"
 )
+
+// sampleSize is how many publishes have to land inside the reload before the
+// measurement is taken. Waiting on the count rather than on wall clock keeps
+// the window the test covers the same on a loaded runner as on an idle one.
+const sampleSize = 200
 
 func swapMsg() corestorage.Messager {
 	m := new(queue.Message)
@@ -63,8 +69,11 @@ func TestAReloadNeverPointsProducersAtAClosedQueue(t *testing.T) {
 	// A consumer that will not finish until this test lets it, so the reload's
 	// Shutdown has something to wait for.
 	release := make(chan struct{})
+	consuming := make(chan struct{})
+	var picked sync.Once
 	first := sdk.Runtime.GetQueuePrefix("")
 	first.Register("t", func(corestorage.Messager) error {
+		picked.Do(func() { close(consuming) })
 		<-release
 		return nil
 	})
@@ -74,7 +83,11 @@ func TestAReloadNeverPointsProducersAtAClosedQueue(t *testing.T) {
 			t.Fatalf("seed append %d: %v", i, err)
 		}
 	}
-	time.Sleep(100 * time.Millisecond) // let the consumer pick one up and block
+	select {
+	case <-consuming:
+	case <-time.After(10 * time.Second):
+		t.Fatal("the consumer never picked a message up, so the reload has nothing to wait for")
+	}
 
 	reloaded := make(chan struct{})
 	go func() { Setup(); close(reloaded) }()
@@ -103,20 +116,24 @@ func TestAReloadNeverPointsProducersAtAClosedQueue(t *testing.T) {
 		}
 	}()
 
-	time.Sleep(200 * time.Millisecond) // the reload is now inside Shutdown's wait
+	deadline := time.After(30 * time.Second)
+	for attempts.Load() < sampleSize {
+		select {
+		case <-deadline:
+			t.Fatalf("only %d publishes landed inside the reload; the window was never sampled", attempts.Load())
+		case <-time.After(time.Millisecond):
+		}
+	}
 	close(release)
 
 	select {
 	case <-reloaded:
-	case <-time.After(10 * time.Second):
+	case <-time.After(30 * time.Second):
 		t.Fatal("the reload never finished")
 	}
 	close(stop)
 	<-publishing
 
-	if attempts.Load() == 0 {
-		t.Fatal("nothing was published during the reload; the test proves nothing")
-	}
 	if n := refused.Load(); n > 1 {
 		t.Errorf("%d of %d publishes during the reload were refused: producers were pointed at the closed queue",
 			n, attempts.Load())

--- a/common/storage/queue_swap_test.go
+++ b/common/storage/queue_swap_test.go
@@ -33,6 +33,16 @@ func swapMsg() corestorage.Messager {
 // The difference is only visible during that wait, which is why the test holds
 // a consumer rather than checking the state after Setup has returned: by then
 // the two orders look identical.
+//
+// One refusal survives the fix and is not something this ordering can reach.
+// GetQueuePrefix hands back a wrapper that captured the adapter, so a producer
+// that fetched before the swap and appends after Shutdown has begun is still
+// holding the old one. That window is one call wide and closing it means
+// resolving the adapter inside Append, which is core's to change. What the
+// ordering removes is the sustained window: every producer that fetches during
+// the wait. The test publishes from a single goroutine, so at most one of its
+// calls can straddle the swap - which is what makes "more than one" the line
+// between the two orders rather than a tolerance.
 func TestAReloadNeverPointsProducersAtAClosedQueue(t *testing.T) {
 	prevQ, prevC := config.QueueConfig, config.CacheConfig
 	prevRuntime := sdk.Runtime
@@ -107,7 +117,7 @@ func TestAReloadNeverPointsProducersAtAClosedQueue(t *testing.T) {
 	if attempts.Load() == 0 {
 		t.Fatal("nothing was published during the reload; the test proves nothing")
 	}
-	if n := refused.Load(); n > 0 {
+	if n := refused.Load(); n > 1 {
 		t.Errorf("%d of %d publishes during the reload were refused: producers were pointed at the closed queue",
 			n, attempts.Load())
 	}

--- a/common/storage/queue_swap_test.go
+++ b/common/storage/queue_swap_test.go
@@ -73,7 +73,12 @@ func TestAReloadNeverPointsProducersAtAClosedQueue(t *testing.T) {
 	var refused atomic.Int64
 	var attempts atomic.Int64
 	stop := make(chan struct{})
+	// publishing is closed by the producer on its way out. The test joins on it
+	// before returning: t.Cleanup restores sdk.Runtime, and a producer still in
+	// flight would be reading the variable that restore writes.
+	publishing := make(chan struct{})
 	go func() {
+		defer close(publishing)
 		for {
 			select {
 			case <-stop:
@@ -97,6 +102,7 @@ func TestAReloadNeverPointsProducersAtAClosedQueue(t *testing.T) {
 		t.Fatal("the reload never finished")
 	}
 	close(stop)
+	<-publishing
 
 	if attempts.Load() == 0 {
 		t.Fatal("nothing was published during the reload; the test proves nothing")

--- a/common/storage/queue_swap_test.go
+++ b/common/storage/queue_swap_test.go
@@ -62,7 +62,10 @@ func TestAReloadNeverPointsProducersAtAClosedQueue(t *testing.T) {
 	})
 	sdk.Runtime = runtime.NewConfig()
 	config.CacheConfig = &config.Cache{Memory: struct{}{}}
-	config.QueueConfig = &config.Queue{Memory: &config.QueueMemory{PoolSize: 64}}
+	// Sized so the buffer cannot fill while the consumer is held: a full queue
+	// returns an error of its own, and this test needs every error other than
+	// ErrQueueClosed to mean something it does not model has happened.
+	config.QueueConfig = &config.Queue{Memory: &config.QueueMemory{PoolSize: 4096}}
 
 	Setup()
 
@@ -95,6 +98,7 @@ func TestAReloadNeverPointsProducersAtAClosedQueue(t *testing.T) {
 	// Publish continuously while the reload is in progress.
 	var refused atomic.Int64
 	var attempts atomic.Int64
+	unexpected := make(chan error, 1)
 	stop := make(chan struct{})
 	// publishing is closed by the producer on its way out. The test joins on it
 	// before returning: t.Cleanup restores sdk.Runtime, and a producer still in
@@ -109,8 +113,19 @@ func TestAReloadNeverPointsProducersAtAClosedQueue(t *testing.T) {
 			default:
 			}
 			attempts.Add(1)
-			if err := sdk.Runtime.GetQueuePrefix("").Append(swapMsg()); errors.Is(err, corestorage.ErrQueueClosed) {
+			err := sdk.Runtime.GetQueuePrefix("").Append(swapMsg())
+			switch {
+			case err == nil:
+			case errors.Is(err, corestorage.ErrQueueClosed):
 				refused.Add(1)
+			default:
+				// Kept rather than counted: an Append refused for some other
+				// reason would otherwise leave refused at zero and the test
+				// green while nothing was reaching a queue at all.
+				select {
+				case unexpected <- err:
+				default:
+				}
 			}
 			time.Sleep(time.Millisecond)
 		}
@@ -134,6 +149,11 @@ func TestAReloadNeverPointsProducersAtAClosedQueue(t *testing.T) {
 	close(stop)
 	<-publishing
 
+	select {
+	case err := <-unexpected:
+		t.Fatalf("a publish failed for a reason this test does not model: %v", err)
+	default:
+	}
 	if n := refused.Load(); n > 1 {
 		t.Errorf("%d of %d publishes during the reload were refused: producers were pointed at the closed queue",
 			n, attempts.Load())

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/casbin/casbin/v3 v3.8.1
 	github.com/gin-gonic/gin v1.12.0
 	github.com/glebarez/sqlite v1.11.0
-	github.com/go-admin-team/go-admin-core/v2 v2.6.0
+	github.com/go-admin-team/go-admin-core/v2 v2.7.0
 	github.com/google/uuid v1.6.0
 	github.com/huaweicloud/huaweicloud-sdk-go-obs v3.26.6+incompatible
 	github.com/mssola/user_agent v0.6.0

--- a/go.sum
+++ b/go.sum
@@ -149,6 +149,8 @@ github.com/go-admin-team/go-admin-core/v2 v2.5.0 h1:aD1SALklBxizGB9u8cOgm4OT8z65
 github.com/go-admin-team/go-admin-core/v2 v2.5.0/go.mod h1:LG/XvEfOplbuadKrPTPm0Nu5pN06aQUNZZC3ao4B4gs=
 github.com/go-admin-team/go-admin-core/v2 v2.6.0 h1:sRoZaxniTpbe287uR/uWpA14Jl1GTAcfGXLKoBLph2w=
 github.com/go-admin-team/go-admin-core/v2 v2.6.0/go.mod h1:LG/XvEfOplbuadKrPTPm0Nu5pN06aQUNZZC3ao4B4gs=
+github.com/go-admin-team/go-admin-core/v2 v2.7.0 h1:1qV0/5iFBvkE3BRtm4ip0v0QYG9Fgx4UtOTd8zkQT9c=
+github.com/go-admin-team/go-admin-core/v2 v2.7.0/go.mod h1:LG/XvEfOplbuadKrPTPm0Nu5pN06aQUNZZC3ao4B4gs=
 github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-kit/kit v0.9.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-kit/kit v0.10.0/go.mod h1:xUsJbQ/Fp4kEt7AFgCuvyX4a71u8h9jB8tj/ORgOZ7o=


### PR DESCRIPTION
core v2.7.0 修好了「队列关闭时丢消息、消费者永不退出」
（[go-admin-core#150](https://github.com/go-admin-team/go-admin-core/pull/150)）。
本 PR 升级依赖，并改掉一处因此变得有害的顺序。

## 为什么顺序要改

`Shutdown` 现在会**等消费者把已收下的消息投递完**。而 `setupQueue` 是先关旧队列、
后装新队列——于是在整个等待期间，`sdk.Runtime` 仍然指着那个已经停止接收的适配器：

- 窗口内的每一次 `Append` 返回 `ErrQueueClosed`
- `common/middleware/logger.go` 与 `handler/auth.go` 都把它记为 **error**
- 对应的日志行一条都不落库

实测:**一次热重载期间 178 次投递，177 次被拒。**

## 改法

先装新的，再关旧的。旧队列照样排空，因为 `Shutdown` 就是等这件事的。

## 这个顺序能给到的边界

**窗口从整个等待期收窄到一次调用宽，不是关死。**

`GetQueuePrefix()` 返回的包装**在构造时就把 adapter 存进了字段**，`Append` 用的是这份
快照。所以一个在换挡前取到句柄、在 `Shutdown` 已经开始之后才 `Append` 的生产者，
手上仍然是旧队列。换挡之后才取句柄的生产者一律拿到新队列。

要把这一次也消掉，得让 `Append` 在调用时解析 adapter，那是 core 侧的改动，不在本 PR。

## 测试为什么要卡在窗口里

这个差别**只在等待期间存在**——`Setup` 返回之后，两种顺序看起来完全一样。

所以测试按住一个消费者不放，让重载的 `Shutdown` 有东西要等，
同时在另一个 goroutine 里持续投递，数有多少次被拒。测试只有一个生产者 goroutine，
所以最多只有一次调用能横跨换挡——「超过一次」因此是两种顺序的分界线，不是容忍度。

## 验证

反证（换回「先关后装」）编译通过，`-race` 下 5/5 红，报 **199～201 次拒绝 / 200 次投递**；
修复态 `-race -count=15` 全绿，实测 0～1 次。

`go build` / `go vet` / `make checksilent` 退出码均为 0；
带 redis 的 `go test -race ./...` 退出码 0，24 个包通过。
