### PR TITLE
docs📝: 摘除实例的不是 readiness——订正 #908 的三处注释

### DIFF
--- a/app/other/router/monitor.go
+++ b/app/other/router/monitor.go
@@ -38,9 +38,9 @@ func registerMonitorRouter(v1 *gin.RouterGroup) {
 	// 就绪检查
 	//
 	// The answer to "should I send you requests". It fails while a dependency
-	// is unreachable, and from the moment shutdown begins - which is before
-	// the server stops accepting, so a load balancer can take this instance
-	// out of the pool while it can still finish what it has.
+	// is unreachable, and from the moment shutdown begins. Nothing waits on
+	// that second answer today, so it is readable rather than actionable -
+	// the package comment in common/health says what it would take.
 	v1.GET("/ready", func(c *gin.Context) {
 		if health.Draining() {
 			c.JSON(http.StatusServiceUnavailable, gin.H{

--- a/cmd/api/server.go
+++ b/cmd/api/server.go
@@ -219,10 +219,10 @@ func run() error {
 	// that has already run.
 	sdk.Runtime.BeginShutdown()
 	// Readiness fails from here, which is before the server stops accepting.
-	// The order is the whole point: a load balancer that is told "not ready"
-	// while this instance can still finish what it has in flight takes it out
-	// of the pool without dropping anything. Reversed, the connections are cut
-	// first and the health check reports it afterwards.
+	// That order is necessary and not sufficient: reversed, the state is
+	// reported after the connections are already cut, but as written there is
+	// nothing between the two lines for a balancer to observe. See the package
+	// comment in common/health.
 	health.BeginDraining()
 
 	log.Info("Shutdown Server ... ")

--- a/common/health/health.go
+++ b/common/health/health.go
@@ -11,8 +11,20 @@
 //   - /ready is readiness: should this instance receive requests now. It fails
 //     while the dependencies are unreachable, and - the part that only exists
 //     because of the life-cycle phases - it fails as soon as shutdown begins,
-//     before the server stops accepting, so a load balancer has a chance to
-//     take the instance out before connections are cut.
+//     before the server stops accepting.
+//
+// # What the draining answer is worth today
+//
+// It is an answer that can be read, not one a balancer acts on. Nothing waits
+// between the flip and the shutdown, and a poller on a multi-second interval
+// never observes it. On Kubernetes the endpoint is withdrawn when the Pod
+// receives a deletionTimestamp, concurrently with SIGTERM and whatever the
+// probe returns; the probe result is not what removes it.
+//
+// Answering before the server stops accepting is still the right order - the
+// reverse reports the state after the connections are already cut - but order
+// alone does not produce a window. That needs a configured delay between the
+// two, which this process does not have.
 package health
 
 import (


### PR DESCRIPTION
#908 在三处注释里写了同一句因果，这句因果不成立。

## 原文说了什么

> readiness 在服务器停止接收之前就转为失败，**于是负载均衡器有机会在连接被切断之前
> 把这个实例摘出去**。

三处：`cmd/api/server.go`、`app/other/router/monitor.go`、`common/health/health.go`。

## 为什么不成立

**① 两行之间什么都没有。** `health.BeginDraining()` 的下一句就是 `shutdownServer()`。
轮询间隔是秒级的（k8s `periodSeconds` 默认 10，`failureThreshold` 默认 3），
没有任何轮询者能观察到这个翻转。

**② 在 k8s 上摘除根本不由探针驱动。** Pod 被删时 `deletionTimestamp` 一置上，
endpoints controller 就摘除，**与 SIGTERM 并发**，不看 readiness 返回什么。

## 改成什么

顺序本身是对的——反过来是「连接已经切断之后才报告状态」，更糟。
所以注释现在说的是**这个顺序必要但不充分**：要形成窗口，需要在两者之间加一个
可配置的延迟，而这个延迟目前不存在。

`common/health` 的包注释承载完整说明，另外两处指向它。

## 范围

只改注释，无行为变更。`go build` / `make checksilent` / `go test -race` 均通过。

延迟本身是 007 那批的内容，不在本 PR。
