### PR TITLE
feat✨: 关闭时先排空再停止接收——让 /ready 的 503 真的能被采到

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -115,7 +115,14 @@ jobs:
             if sudo docker ps -a --format '{{.Names}}' | grep -qx "$NAME"; then
               sudo docker rm -f "$PREV" >/dev/null 2>&1 || true
               sudo docker rename "$NAME" "$PREV"
-              sudo docker stop "$PREV" >/dev/null
+              # --timeout, because the default is 10 seconds and the process
+              # spends drain + server + cleanup from extend.shutdown before it
+              # exits - 8 seconds out of the box, and more for anyone who
+              # configures a drain window. Past the deadline docker sends
+              # SIGKILL and the cleanup callbacks are cut off part-way through.
+              # checksilent's docker-stop-cuts-shutdown-short check compares
+              # this number against config/settings.yml.
+              sudo docker stop --timeout 30 "$PREV" >/dev/null
             fi
 
             sudo docker run -d -p 8000:8000 \

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -227,8 +227,9 @@ go run -tags sqlite3 . server  -c config/settings.sqlite.yml
 
 ## 静默失败校验
 
-`make checksilent` 检查七类**不报错、不记日志、行为悄悄变得不对**的问题，
-CI 会跑，命中 ERROR 即失败：
+`make checksilent` 逐条检查那些**不报错、不记日志、行为悄悄变得不对**的问题，
+CI 会跑，命中 ERROR 即失败。这里不写条数——写死的数字会悄悄过时，
+真正的清单是 `tools/checksilent/checks.go` 里 `runChecks` 跑的那几个：
 
 | 检查 | 级别 | 静默后果 |
 |---|---|---|
@@ -238,7 +239,14 @@ CI 会跑，命中 ERROR 即失败：
 | `menu-id-collision` | ERROR | 两个模块硬编码同一菜单 ID，互相覆盖 |
 | `contract-import-boundary` | ERROR | 契约包 import `app/`，应用无法独立编译 |
 | `contract-shim-alias` | ERROR | 契约薄壳写成 defined type 而非别名，方法集丢失，本仓可能照常编译、第三方应用编译不过 |
+| `datascope-route-unguarded` | ERROR | handler 读调用方的数据权限，而注册它的路由组没装提供权限的中间件。取不到时拿到零值、走 fail-closed 分支，查询被塞进 `1 = 0`：接口对确实存在的行返回「查不到」，且只在 `enabledp: true` 的部署上出现 |
+| `shutdown-budget-overruns-grace` | ERROR / WARN | `settings.yml` 的 `extend.shutdown` 预算（含清单里的 `preStop`）放不进自带 k8s 清单的 `terminationGracePeriodSeconds`，SIGKILL 在清理回调跑到一半时到达 |
+| `docker-stop-cuts-shutdown-short` | ERROR / WARN | 停止容器的两条路径——脚本/工作流里的 `docker stop`，和 `docker-compose.yml` 的 `stop_grace_period`——没写或写得不够关闭预算用。两边默认都是 10 秒，而这个数字离命令很远，调大预算的人不会想起它 |
 | `menu-name-mismatch` | WARN | 菜单名与前端组件 `name` 不一致，keep-alive 缓存静默失效 |
+
+两条关闭预算检查分两级，用的是同一条算术和同一个 5 秒边际：真的超限报 ERROR，
+放得进但余量不足 5 秒报 WARN。余量不足做 WARN 不做 ERROR，是因为那是个技术上
+跑得通的配置——**一条在正确配置下也会响的 ERROR，训练的是忽略它**。
 
 最后一条要跨仓库比对，只能做正则启发式，因此是 WARN，**不影响退出码**，
 且默认跳过；要跑它得指定前端目录：

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,16 @@ build-sqlite:
 # make run
 run:
     # delete go-admin-api container
-	@if [ $(shell docker ps -aq --filter name=go-admin --filter publish=8000) ]; then docker rm -f go-admin; fi
+    #
+    # stop then rm, rather than `rm -f`. The force flag kills a running
+    # container with SIGKILL and no grace at all, so restarting locally cut
+    # short every shutdown this application does - the drain window was never
+    # once reached on a developer's machine. --timeout has to cover
+    # extend.shutdown's drain + server + cleanup; checksilent's
+    # docker-stop-cuts-shutdown-short check compares it against
+    # config/settings.yml. On a container that has already stopped, stop is a
+    # no-op and the removal is unchanged.
+	@if [ $(shell docker ps -aq --filter name=go-admin --filter publish=8000) ]; then docker stop --timeout 30 go-admin && docker rm go-admin; fi
 
     # 启动方法一 run go-admin-api container  docker-compose 启动方式
     # 进入到项目根目录 执行 make run 命令

--- a/app/other/router/monitor.go
+++ b/app/other/router/monitor.go
@@ -53,9 +53,10 @@ func RegisterMonitorRouter(v1 *gin.RouterGroup) {
 	// 就绪检查
 	//
 	// The answer to "should I send you requests". It fails while a dependency
-	// is unreachable, and from the moment shutdown begins. Nothing waits on
-	// that second answer today, so it is readable rather than actionable -
-	// the package comment in common/health says what it would take.
+	// is unreachable, and from the moment shutdown begins - for as long as
+	// extend.shutdown.drain says, which is zero unless it is configured. The
+	// package comment in common/health says what that window is worth, and to
+	// whom.
 	v1.GET(ReadyPath, func(c *gin.Context) {
 		if health.Draining() {
 			c.JSON(http.StatusServiceUnavailable, gin.H{

--- a/app/other/router/monitor.go
+++ b/app/other/router/monitor.go
@@ -16,9 +16,12 @@ func init() {
 	routerNoCheckRole = append(routerNoCheckRole, RegisterMonitorRouter)
 }
 
-// readyTimeout bounds the whole probe. It has to stay under whatever period
-// the orchestrator polls on, or a slow dependency turns a readiness check into
-// a queue of readiness checks.
+// readyTimeout bounds the whole probe. What constrains it is the orchestrator's
+// per-check timeout rather than its polling period: Kubernetes allows a probe
+// one second by default, so a dependency that answers in 1.2s is recorded as a
+// failed check however promptly this handler returns. A manifest that mounts
+// this probe has to raise timeoutSeconds above this value, and
+// scripts/k8s/deploy.yml does.
 const readyTimeout = 2 * time.Second
 
 // HealthPath and ReadyPath are the two probe routes, relative to APIPrefix.

--- a/app/other/router/monitor.go
+++ b/app/other/router/monitor.go
@@ -13,7 +13,7 @@ import (
 )
 
 func init() {
-	routerNoCheckRole = append(routerNoCheckRole, registerMonitorRouter)
+	routerNoCheckRole = append(routerNoCheckRole, RegisterMonitorRouter)
 }
 
 // readyTimeout bounds the whole probe. It has to stay under whatever period
@@ -21,8 +21,23 @@ func init() {
 // a queue of readiness checks.
 const readyTimeout = 2 * time.Second
 
+// HealthPath and ReadyPath are the two probe routes, relative to APIPrefix.
+//
+// Exported for the same reason as the prefix: the rate limiter has to be told
+// to skip them, and it is installed in a package that cannot import this one.
+const (
+	HealthPath = "/health"
+	ReadyPath  = "/ready"
+)
+
+// RegisterMonitorRouter mounts the metrics endpoint and the two probes on v1.
+//
+// Exported so that a test can put the real probes on a server of its own. The
+// alternative - a test that re-implements the handler it means to check - is
+// how a probe comes to be asserted against a copy of itself.
+//
 // 无需认证的路由代码
-func registerMonitorRouter(v1 *gin.RouterGroup) {
+func RegisterMonitorRouter(v1 *gin.RouterGroup) {
 	v1.GET("/metrics", transfer.Handler(promhttp.Handler()))
 
 	// 健康检查（存活）
@@ -31,7 +46,7 @@ func registerMonitorRouter(v1 *gin.RouterGroup) {
 	// you", and a process whose database is unreachable does not want
 	// restarting - that turns one outage into a crash loop and throws away the
 	// connection pool, the cache and every in-flight request along the way.
-	v1.GET("/health", func(c *gin.Context) {
+	v1.GET(HealthPath, func(c *gin.Context) {
 		c.Status(http.StatusOK)
 	})
 
@@ -41,7 +56,7 @@ func registerMonitorRouter(v1 *gin.RouterGroup) {
 	// is unreachable, and from the moment shutdown begins. Nothing waits on
 	// that second answer today, so it is readable rather than actionable -
 	// the package comment in common/health says what it would take.
-	v1.GET("/ready", func(c *gin.Context) {
+	v1.GET(ReadyPath, func(c *gin.Context) {
 		if health.Draining() {
 			c.JSON(http.StatusServiceUnavailable, gin.H{
 				"status": "draining",

--- a/app/other/router/router.go
+++ b/app/other/router/router.go
@@ -10,6 +10,13 @@ var (
 	routerCheckRole   = make([]func(v1 *gin.RouterGroup, authMiddleware *jwt.GinJWTMiddleware), 0)
 )
 
+// APIPrefix is the group every route below is registered under.
+//
+// Exported because the middleware chain in cmd/api has to name two of those
+// routes in full - the rate limiter is installed on the engine and must skip
+// the probes - and a prefix spelled in two places is a prefix that drifts.
+const APIPrefix = "/api/v1"
+
 // initRouter 路由示例
 func initRouter(r *gin.Engine, authMiddleware *jwt.GinJWTMiddleware) *gin.Engine {
 
@@ -24,7 +31,7 @@ func initRouter(r *gin.Engine, authMiddleware *jwt.GinJWTMiddleware) *gin.Engine
 // noCheckRoleRouter 无需认证的路由示例
 func noCheckRoleRouter(r *gin.Engine) {
 	// 可根据业务需求来设置接口版本
-	v1 := r.Group("/api/v1")
+	v1 := r.Group(APIPrefix)
 
 	for _, f := range routerNoCheckRole {
 		f(v1)
@@ -34,7 +41,7 @@ func noCheckRoleRouter(r *gin.Engine) {
 // checkRoleRouter 需要认证的路由示例
 func checkRoleRouter(r *gin.Engine, authMiddleware *jwt.GinJWTMiddleware) {
 	// 可根据业务需求来设置接口版本
-	v1 := r.Group("/api/v1")
+	v1 := r.Group(APIPrefix)
 
 	for _, f := range routerCheckRole {
 		f(v1, authMiddleware)

--- a/cmd/api/server.go
+++ b/cmd/api/server.go
@@ -158,6 +158,14 @@ func attachConsumersOnce(gen uint64, q corestorage.AdapterQueue) {
 }
 
 func run() error {
+	// Resolved first, and refused rather than corrected: a budget that cannot
+	// be spent as written is a configuration error, and the moment to say so
+	// is while nothing depends on this process yet.
+	seconds, err := ext.ExtConfig.Shutdown.Budget()
+	if err != nil {
+		return err
+	}
+
 	if config.ApplicationConfig.Mode == pkg.ModeProd.String() {
 		gin.SetMode(gin.ReleaseMode)
 	}
@@ -209,7 +217,7 @@ func run() error {
 	fmt.Printf("%s Enter Control + C Shutdown Server \r\n", pkg.GetCurrentTimeStr())
 
 	<-quit
-	serverErr, cleanupErr := gracefulShutdown(srv, disarmStopSignals, defaultBudget())
+	serverErr, cleanupErr := gracefulShutdown(srv, disarmStopSignals, budgetFrom(seconds))
 	if serverErr != nil {
 		// Not log.Fatal: that is an unconditional os.Exit(1), and Shutdown
 		// reports an error exactly when connections were still in flight -
@@ -229,7 +237,16 @@ type budget struct {
 	cleanup time.Duration
 }
 
-// defaultBudget is what a shutdown spends today.
+// budgetFrom turns the resolved seconds into the durations the sequence waits
+// on.
+func budgetFrom(s ext.ShutdownBudget) budget {
+	return budget{
+		server:  time.Duration(s.Server) * time.Second,
+		cleanup: time.Duration(s.Cleanup) * time.Second,
+	}
+}
+
+// defaultBudget is what a process with no extend.shutdown section spends.
 func defaultBudget() budget {
 	return budget{server: shutdownTimeout, cleanup: cleanupTimeout}
 }
@@ -277,17 +294,21 @@ func gracefulShutdown(srv *http.Server, disarm func(), b budget) (serverErr, cle
 	return serverErr, cleanupErr
 }
 
-// shutdownTimeout is how long Shutdown waits for in-flight requests, and
-// cleanupTimeout how long the BeforeExit callbacks get after it.
+// The budgets a shutdown spends when extend.shutdown configures nothing:
+// shutdownTimeout waits for in-flight requests, then cleanupTimeout is what
+// the BeforeExit callbacks get.
 //
-// They are consumed one after the other, so the two together are what has to
-// stay inside the orchestrator's grace period: `docker stop` allows 10s by
-// default before it sends SIGKILL, and 5+3 leaves room for the process to
-// finish returning. Raising either without lowering the other buys nothing -
-// the budget that runs out is the orchestrator's.
-const (
-	shutdownTimeout = 5 * time.Second
-	cleanupTimeout  = 3 * time.Second
+// The seconds come from config, which is where an absent field falls back, so
+// the default is one number rather than two that can drift apart.
+//
+// They are consumed one after the other, so their sum is what has to stay
+// inside the orchestrator's grace period: `docker stop` allows 10s by default
+// before it sends SIGKILL, and 5+3 leaves room for the process to finish
+// returning. Raising one without lowering the other buys nothing - the budget
+// that runs out is the orchestrator's.
+var (
+	shutdownTimeout = time.Duration(ext.DefaultServerSeconds) * time.Second
+	cleanupTimeout  = time.Duration(ext.DefaultCleanupSeconds) * time.Second
 )
 
 // armStopSignals registers for the stop signals and returns the channel they

--- a/cmd/api/server.go
+++ b/cmd/api/server.go
@@ -171,6 +171,8 @@ func run() error {
 	if err != nil {
 		return err
 	}
+	reportShutdownBudget(seconds)
+
 	if config.ApplicationConfig.Mode == pkg.ModeProd.String() {
 		gin.SetMode(gin.ReleaseMode)
 	}
@@ -343,6 +345,45 @@ func drain(quit <-chan os.Signal, d time.Duration) {
 		log.Info("Second signal during the drain window, closing the listener now")
 	case <-timer.C:
 	}
+}
+
+// Reference stop grace periods, printed when nothing was configured to compare
+// against. They are three times apart, which is why the check below needs a
+// configured value rather than a constant of its own: a budget that overruns
+// under one of them fits comfortably under the other.
+const (
+	dockerStopGraceSeconds = 10
+	kubernetesGraceSeconds = 30
+)
+
+// reportShutdownBudget states what a shutdown will spend and whether it fits.
+//
+// The sum is taken from the resolved values, not from the configuration file:
+// a field left out of extend.shutdown still costs its default, so adding up
+// what was written down understates the budget by exactly the fields nobody
+// wrote.
+func reportShutdownBudget(s ext.ShutdownBudget) {
+	log.Infof("shutdown budget: drain %ds + server %ds + cleanup %ds = %ds",
+		s.Drain, s.Server, s.Cleanup, s.Total())
+
+	if s.Grace <= 0 {
+		log.Infof("shutdown budget: extend.shutdown.grace is not set, so nothing is compared against it - "+
+			"for reference `docker stop` allows %ds and Kubernetes terminationGracePeriodSeconds defaults to %ds",
+			dockerStopGraceSeconds, kubernetesGraceSeconds)
+		return
+	}
+	if over := s.Overrun(); over > 0 {
+		// A minimum, not a target. This is somebody else's deployment under
+		// constraints this process cannot see, so the honest thing to state is
+		// how much is missing - the repository's own files are where there is
+		// standing to ask for headroom on top, and checksilent does that.
+		log.Warnf("shutdown budget of %ds does not fit inside the %ds of extend.shutdown.grace: "+
+			"SIGKILL arrives while the cleanup callbacks are still running, and the work they "+
+			"were about to finish is lost. It needs at least %ds more, or %ds less budget.",
+			s.Total(), s.Grace, over, over)
+		return
+	}
+	log.Infof("shutdown budget of %ds fits inside the %ds of extend.shutdown.grace", s.Total(), s.Grace)
 }
 
 // The budgets a shutdown spends when extend.shutdown configures nothing:

--- a/cmd/api/server.go
+++ b/cmd/api/server.go
@@ -28,6 +28,7 @@ import (
 	"go-admin/app/admin/models"
 	"go-admin/app/admin/router"
 	"go-admin/app/jobs"
+	otherrouter "go-admin/app/other/router"
 	"go-admin/common/database"
 	"go-admin/common/global"
 	"go-admin/common/health"
@@ -476,10 +477,38 @@ func initRouter() {
 		r.Use(handler.TlsHandler())
 	}
 	//r.Use(middleware.Metrics())
-	r.Use(common.Sentinel()).
+	r.Use(exemptProbes(common.Sentinel())).
 		Use(common.RequestId(pkg.TrafficKey)).
 		Use(api.SetRequestLogger)
 
 	common.InitMiddleware(r)
 
+}
+
+// probePaths are the two routes the rate limiter must not answer for.
+var probePaths = map[string]bool{
+	otherrouter.APIPrefix + otherrouter.HealthPath: true,
+	otherrouter.APIPrefix + otherrouter.ReadyPath:  true,
+}
+
+// exemptProbes wraps a middleware so the health and readiness routes skip it.
+//
+// The limiter is installed on the engine and the probes are routes like any
+// other, so above the threshold they are answered with 429 as well. A liveness
+// probe that collects 429s fails its threshold and the container is restarted,
+// which takes capacity out of a deployment that is already short of it and
+// pushes the rest closer to the threshold - the limiter working exactly as
+// intended is what causes it. It is the argument common/health makes about
+// restarting a process whose database is unreachable, applied to load.
+//
+// Wrapping rather than teaching the limiter about these paths: the limiter
+// lives under common/, which may not import the package that registers them.
+func exemptProbes(h gin.HandlerFunc) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		if probePaths[c.FullPath()] {
+			c.Next()
+			return
+		}
+		h(c)
+	}
 }

--- a/cmd/api/server.go
+++ b/cmd/api/server.go
@@ -159,14 +159,18 @@ func attachConsumersOnce(gen uint64, q corestorage.AdapterQueue) {
 }
 
 func run() error {
-	// Resolved first, and refused rather than corrected: a budget that cannot
-	// be spent as written is a configuration error, and the moment to say so
-	// is while nothing depends on this process yet.
+	// Resolved first, and used both for the line it prints and for the
+	// shutdown that spends it. Reading the configuration again at signal time
+	// would let the two disagree, and the sum that gets printed is the whole
+	// point of printing it.
+	//
+	// Refused rather than corrected, and refused before anything is built: a
+	// budget that cannot be spent as written is a configuration error, and the
+	// moment to say so is while nothing depends on this process yet.
 	seconds, err := ext.ExtConfig.Shutdown.Budget()
 	if err != nil {
 		return err
 	}
-
 	if config.ApplicationConfig.Mode == pkg.ModeProd.String() {
 		gin.SetMode(gin.ReleaseMode)
 	}
@@ -218,7 +222,7 @@ func run() error {
 	fmt.Printf("%s Enter Control + C Shutdown Server \r\n", pkg.GetCurrentTimeStr())
 
 	<-quit
-	serverErr, cleanupErr := gracefulShutdown(srv, disarmStopSignals, budgetFrom(seconds))
+	serverErr, cleanupErr := gracefulShutdown(srv, quit, disarmStopSignals, budgetFrom(seconds))
 	if serverErr != nil {
 		// Not log.Fatal: that is an unconditional os.Exit(1), and Shutdown
 		// reports an error exactly when connections were still in flight -
@@ -232,8 +236,9 @@ func run() error {
 	return nil
 }
 
-// budget is the waits a shutdown spends, in the order it spends them.
+// budget is the three waits a shutdown spends, in the order it spends them.
 type budget struct {
+	drain   time.Duration
 	server  time.Duration
 	cleanup time.Duration
 }
@@ -242,6 +247,7 @@ type budget struct {
 // on.
 func budgetFrom(s ext.ShutdownBudget) budget {
 	return budget{
+		drain:   time.Duration(s.Drain) * time.Second,
 		server:  time.Duration(s.Server) * time.Second,
 		cleanup: time.Duration(s.Cleanup) * time.Second,
 	}
@@ -249,40 +255,64 @@ func budgetFrom(s ext.ShutdownBudget) budget {
 
 // defaultBudget is what a process with no extend.shutdown section spends.
 func defaultBudget() budget {
-	return budget{server: shutdownTimeout, cleanup: cleanupTimeout}
+	return budget{drain: drainTimeout, server: shutdownTimeout, cleanup: cleanupTimeout}
 }
 
 // gracefulShutdown takes the process down in the order that gives something
 // else a chance to notice first.
 //
-// The whole order lives here so that it has one home. run() is not meant to be
-// the only caller: a test that reproduces this sequence instead of running it
-// asserts against its own copy, and stays green while the sequence it was
-// written for regresses.
+// The whole order lives here, and run() is not the only caller: the signal
+// tests run this function rather than reproducing it. A test that reproduces a
+// sequence asserts against its own copy and stays green while the sequence it
+// was written for regresses.
 //
-// The caller has already taken the stop signal off its channel. disarm is
-// called first, before anything is taken apart: from that point a second
-// signal reaches the default handler again, so a shutdown that hangs can still
-// be interrupted.
+// The caller has already taken the first signal off quit. quit is handed on
+// because a second signal during the drain window ends the window early -
+// somebody sending another kill wants this over with sooner - and because
+// until the window is over that signal must not reach the default handler and
+// kill the process outright.
+//
+// disarm is therefore called at the end of the window rather than on the first
+// signal. After it, a second signal is handled by the default disposition
+// again, which is the only way out of a Shutdown or a cleanup callback that
+// never returns. Restoring it any earlier would put every ordinary shutdown
+// inside that escape hatch for the whole length of the drain, where before
+// this window existed only a hung callback could reach it.
 //
 // The two waits' errors are returned separately rather than logged: they fail
 // for different reasons, and the caller decides what each is worth.
-func gracefulShutdown(srv *http.Server, disarm func(), b budget) (serverErr, cleanupErr error) {
-	// Restored here, not deferred: from this point a second signal must reach
-	// the default handler, so a shutdown that hangs can still be interrupted.
-	disarm()
-
+func gracefulShutdown(srv *http.Server, quit <-chan os.Signal, disarm func(), b budget) (serverErr, cleanupErr error) {
 	// Said before anything is taken apart. A configuration reload arriving in
 	// this window would otherwise re-run AfterResource - rebuilding the pool
 	// and the queue adapter, and re-registering consumers - on top of cleanup
 	// that has already run.
 	sdk.Runtime.BeginShutdown()
+
 	// Readiness fails from here, which is before the server stops accepting.
-	// That order is necessary and not sufficient: reversed, the state is
-	// reported after the connections are already cut, but as written there is
-	// nothing between the two lines for a balancer to observe. See the package
-	// comment in common/health.
+	// That order is necessary and not sufficient: with nothing between this
+	// line and the listener closing, the two are microseconds apart and a
+	// poller on a multi-second interval sees the refused connection instead of
+	// the 503. The window below is what turns the order into something
+	// observable - extend.shutdown.drain, which is zero unless it is
+	// configured.
 	health.BeginDraining()
+
+	// Keep-alive off for the same window, and for the same reason. The server
+	// keeps connections alive while !disableKeepAlives && !shuttingDown(), and
+	// shuttingDown() is only set by Shutdown itself - so without this line
+	// every pooled connection stays open for the whole drain and is cut at the
+	// end of it anyway, which is the cost of the window without its benefit.
+	// This is the switch Shutdown flips, moved earlier by the window's length:
+	// answers now carry Connection: close, and the idle connections a balancer
+	// is holding are closed at once rather than when it next tries to use one.
+	srv.SetKeepAlivesEnabled(false)
+
+	drain(quit, b.drain)
+
+	// Restored here, not on the first signal: from this point a second signal
+	// must reach the default handler, so a shutdown that hangs can still be
+	// interrupted.
+	disarm()
 
 	log.Info("Shutdown Server ... ")
 	serverErr = shutdownServer(srv, b.server)
@@ -295,7 +325,28 @@ func gracefulShutdown(srv *http.Server, disarm func(), b budget) (serverErr, cle
 	return serverErr, cleanupErr
 }
 
+// drain keeps serving for d, or until another stop signal arrives.
+//
+// Requests are answered normally throughout. Refusing them would move the
+// outage earlier rather than avoid it - the point of the window is that this
+// instance is still able to work while whoever routes to it stops routing.
+func drain(quit <-chan os.Signal, d time.Duration) {
+	if d <= 0 {
+		return
+	}
+	log.Infof("Draining for %s: still serving, /ready answers 503 from here", d)
+
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+	select {
+	case <-quit:
+		log.Info("Second signal during the drain window, closing the listener now")
+	case <-timer.C:
+	}
+}
+
 // The budgets a shutdown spends when extend.shutdown configures nothing:
+// drainTimeout keeps the process serving after the stop signal, then
 // shutdownTimeout waits for in-flight requests, then cleanupTimeout is what
 // the BeforeExit callbacks get.
 //
@@ -304,10 +355,12 @@ func gracefulShutdown(srv *http.Server, disarm func(), b budget) (serverErr, cle
 //
 // They are consumed one after the other, so their sum is what has to stay
 // inside the orchestrator's grace period: `docker stop` allows 10s by default
-// before it sends SIGKILL, and 5+3 leaves room for the process to finish
-// returning. Raising one without lowering the other buys nothing - the budget
-// that runs out is the orchestrator's.
+// before it sends SIGKILL, and 0+5+3 leaves room for the process to finish
+// returning. Raising one without lowering another buys nothing - the budget
+// that runs out is the orchestrator's, and reportShutdownBudget is what says
+// so at start-up.
 var (
+	drainTimeout    = time.Duration(ext.DefaultDrainSeconds) * time.Second
 	shutdownTimeout = time.Duration(ext.DefaultServerSeconds) * time.Second
 	cleanupTimeout  = time.Duration(ext.DefaultCleanupSeconds) * time.Second
 )

--- a/cmd/api/server.go
+++ b/cmd/api/server.go
@@ -209,9 +209,50 @@ func run() error {
 	fmt.Printf("%s Enter Control + C Shutdown Server \r\n", pkg.GetCurrentTimeStr())
 
 	<-quit
+	serverErr, cleanupErr := gracefulShutdown(srv, disarmStopSignals, defaultBudget())
+	if serverErr != nil {
+		// Not log.Fatal: that is an unconditional os.Exit(1), and Shutdown
+		// reports an error exactly when connections were still in flight -
+		// which is when the cleanup that ran after it mattered most.
+		log.Error("Server Shutdown: ", serverErr)
+	}
+	if cleanupErr != nil {
+		log.Error("Cleanup: ", cleanupErr)
+	}
+
+	return nil
+}
+
+// budget is the waits a shutdown spends, in the order it spends them.
+type budget struct {
+	server  time.Duration
+	cleanup time.Duration
+}
+
+// defaultBudget is what a shutdown spends today.
+func defaultBudget() budget {
+	return budget{server: shutdownTimeout, cleanup: cleanupTimeout}
+}
+
+// gracefulShutdown takes the process down in the order that gives something
+// else a chance to notice first.
+//
+// The whole order lives here so that it has one home. run() is not meant to be
+// the only caller: a test that reproduces this sequence instead of running it
+// asserts against its own copy, and stays green while the sequence it was
+// written for regresses.
+//
+// The caller has already taken the stop signal off its channel. disarm is
+// called first, before anything is taken apart: from that point a second
+// signal reaches the default handler again, so a shutdown that hangs can still
+// be interrupted.
+//
+// The two waits' errors are returned separately rather than logged: they fail
+// for different reasons, and the caller decides what each is worth.
+func gracefulShutdown(srv *http.Server, disarm func(), b budget) (serverErr, cleanupErr error) {
 	// Restored here, not deferred: from this point a second signal must reach
 	// the default handler, so a shutdown that hangs can still be interrupted.
-	disarmStopSignals()
+	disarm()
 
 	// Said before anything is taken apart. A configuration reload arriving in
 	// this window would otherwise re-run AfterResource - rebuilding the pool
@@ -226,20 +267,14 @@ func run() error {
 	health.BeginDraining()
 
 	log.Info("Shutdown Server ... ")
-	if err := shutdownServer(srv, shutdownTimeout); err != nil {
-		// Not log.Fatal: that is an unconditional os.Exit(1), and Shutdown
-		// reports an error exactly when connections were still in flight -
-		// which is when the cleanup that follows matters most.
-		log.Error("Server Shutdown: ", err)
-	}
-
-	// Runs whether or not the line above reported an error, for that reason.
-	if err := runShutdownHooks(cleanupTimeout); err != nil {
-		log.Error("Cleanup: ", err)
-	}
+	serverErr = shutdownServer(srv, b.server)
+	// Runs whether or not the wait above failed, and deliberately so: Shutdown
+	// reports an error exactly when connections were still in flight, which is
+	// when there is most left to clean up after.
+	cleanupErr = runShutdownHooks(b.cleanup)
 	log.Info("Server exiting")
 
-	return nil
+	return serverErr, cleanupErr
 }
 
 // shutdownTimeout is how long Shutdown waits for in-flight requests, and

--- a/cmd/api/shutdown_test.go
+++ b/cmd/api/shutdown_test.go
@@ -9,14 +9,16 @@ import (
 	"github.com/gin-gonic/gin"
 
 	otherrouter "go-admin/app/other/router"
+	"go-admin/common/health"
 	ext "go-admin/config"
 )
 
 // The seconds in the configuration and the durations the sequence waits on are
-// two spellings of one budget.
+// two spellings of one budget, and only one of them is printed at start-up.
 func TestBudgetFromSeconds(t *testing.T) {
-	got := budgetFrom(ext.ShutdownBudget{Server: 5, Cleanup: 3})
+	got := budgetFrom(ext.ShutdownBudget{Drain: 10, Server: 5, Cleanup: 3})
 	want := budget{
+		drain:   10 * time.Second,
 		server:  5 * time.Second,
 		cleanup: 3 * time.Second,
 	}
@@ -98,5 +100,40 @@ func TestTheProbesSkipTheRateLimiter(t *testing.T) {
 		if probePaths[p] {
 			t.Errorf("the middleware ran for %s", p)
 		}
+	}
+}
+
+// /health has to stay 200 while draining, and it is the assertion most easily
+// lost by accident: making the liveness probe follow the readiness flag reads
+// like tidying up, and it turns every rolling restart into a kubelet-issued
+// kill part-way through the drain.
+func TestHealthStaysUpWhileDraining(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	r := gin.New()
+	v1 := r.Group(otherrouter.APIPrefix)
+	otherrouter.RegisterMonitorRouter(v1)
+
+	ask := func(path string) int {
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, path, nil))
+		return w.Code
+	}
+
+	if got := ask(otherrouter.APIPrefix + otherrouter.HealthPath); got != http.StatusOK {
+		t.Fatalf("/health answered %d before draining, want 200", got)
+	}
+
+	// Process-wide and one-way - nothing clears it - so this is the last thing
+	// in this package that may run in-process and care. Everything else that
+	// exercises draining does so in a child process of its own.
+	health.BeginDraining()
+
+	if got := ask(otherrouter.APIPrefix + otherrouter.HealthPath); got != http.StatusOK {
+		t.Errorf("/health answered %d while draining, want 200 - liveness is "+
+			"\"should I restart you\", and the answer during a drain is no", got)
+	}
+	if got := ask(otherrouter.APIPrefix + otherrouter.ReadyPath); got != http.StatusServiceUnavailable {
+		t.Errorf("/ready answered %d while draining, want 503", got)
 	}
 }

--- a/cmd/api/shutdown_test.go
+++ b/cmd/api/shutdown_test.go
@@ -1,0 +1,35 @@
+package api
+
+import (
+	"testing"
+	"time"
+
+	ext "go-admin/config"
+)
+
+// The seconds in the configuration and the durations the sequence waits on are
+// two spellings of one budget.
+func TestBudgetFromSeconds(t *testing.T) {
+	got := budgetFrom(ext.ShutdownBudget{Server: 5, Cleanup: 3})
+	want := budget{
+		server:  5 * time.Second,
+		cleanup: 3 * time.Second,
+	}
+	if got != want {
+		t.Errorf("budgetFrom = %+v, want %+v", got, want)
+	}
+}
+
+// The package variables and config.Default*Seconds have to say the same thing.
+// They are the same default written twice - once as durations for the shutdown
+// and once as seconds for the fallback - and a deployment that configures
+// nothing is entitled to one answer, not two.
+func TestDefaultBudgetIsTheConfiguredFallback(t *testing.T) {
+	unconfigured, err := ext.Shutdown{}.Budget()
+	if err != nil {
+		t.Fatalf("the empty section did not resolve: %v", err)
+	}
+	if got, want := defaultBudget(), budgetFrom(unconfigured); got != want {
+		t.Errorf("defaultBudget = %+v, want the unconfigured budget %+v", got, want)
+	}
+}

--- a/cmd/api/shutdown_test.go
+++ b/cmd/api/shutdown_test.go
@@ -1,9 +1,14 @@
 package api
 
 import (
+	"net/http"
+	"net/http/httptest"
 	"testing"
 	"time"
 
+	"github.com/gin-gonic/gin"
+
+	otherrouter "go-admin/app/other/router"
 	ext "go-admin/config"
 )
 
@@ -31,5 +36,67 @@ func TestDefaultBudgetIsTheConfiguredFallback(t *testing.T) {
 	}
 	if got, want := defaultBudget(), budgetFrom(unconfigured); got != want {
 		t.Errorf("defaultBudget = %+v, want the unconfigured budget %+v", got, want)
+	}
+}
+
+// The rate limiter must not answer for the probes.
+//
+// It is installed on the engine, so without this the probes are limited like
+// any other route and answer 429 above the threshold. A liveness probe that
+// collects 429s fails its threshold and the container is restarted - taking
+// capacity out of a deployment that is already short of it and pushing the
+// rest closer to the threshold. The limiter working exactly as designed is
+// what would cause it.
+//
+// The stand-in rejects everything rather than being a real limiter: what is
+// under test is which requests reach it, and a real one would need the traffic
+// to cross a threshold before it said anything.
+func TestTheProbesSkipTheRateLimiter(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	var reached []string
+	r := gin.New()
+	r.Use(exemptProbes(func(c *gin.Context) {
+		reached = append(reached, c.FullPath())
+		c.AbortWithStatus(http.StatusTooManyRequests)
+	}))
+	v1 := r.Group(otherrouter.APIPrefix)
+	otherrouter.RegisterMonitorRouter(v1)
+	v1.GET("/business", func(c *gin.Context) { c.Status(http.StatusOK) })
+
+	for _, tc := range []struct {
+		path    string
+		limited bool
+	}{
+		{otherrouter.APIPrefix + otherrouter.HealthPath, false},
+		{otherrouter.APIPrefix + otherrouter.ReadyPath, false},
+		// Not a probe, and deliberately not exempt: the exemption is for the
+		// two routes an orchestrator acts on, not for everything under
+		// /api/v1 that happens to be unauthenticated.
+		{otherrouter.APIPrefix + "/metrics", true},
+		{otherrouter.APIPrefix + "/business", true},
+	} {
+		t.Run(tc.path, func(t *testing.T) {
+			w := httptest.NewRecorder()
+			r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, tc.path, nil))
+
+			if tc.limited {
+				if w.Code != http.StatusTooManyRequests {
+					t.Errorf("answered %d, want the middleware's 429 - it was skipped for a route that is not a probe", w.Code)
+				}
+				return
+			}
+			if w.Code == http.StatusTooManyRequests {
+				t.Errorf("answered 429; a probe that can be rate-limited gets the container restarted under load")
+			}
+		})
+	}
+
+	// Said separately, because a probe could also answer 429 by itself: what
+	// has to be true is that the middleware never saw the request.
+	for _, p := range reached {
+		if probePaths[p] {
+			t.Errorf("the middleware ran for %s", p)
+		}
 	}
 }

--- a/cmd/api/signal_test.go
+++ b/cmd/api/signal_test.go
@@ -3,38 +3,63 @@ package api
 import (
 	"context"
 	"fmt"
+	"io"
 	"net"
 	"net/http"
 	"os"
 	"os/exec"
+	"strconv"
 	"strings"
+	"sync"
 	"syscall"
 	"testing"
 	"time"
 
+	"github.com/gin-gonic/gin"
 	"github.com/go-admin-team/go-admin-core/v2/sdk"
+
+	otherrouter "go-admin/app/other/router"
 )
 
 // The signal path cannot be exercised in-process: delivering a signal to the
 // test binary would race with the test framework, and the disposition changes
 // are global. So the test re-executes itself as a child, and the child runs
 // gracefulShutdown - the same function run() runs, not a second copy of the
-// sequence. A test that reproduces a sequence asserts against its own copy and
-// stays green while the sequence it was written for regresses.
+// sequence. A test that reproduces the sequence asserts against its own copy:
+// move BeginDraining after the drain window and the process regresses while
+// the test stays green, which is the failure mode this file exists to avoid.
 //
-// The child deliberately serves an empty http.Server rather than the real one:
-// this repository's CI has no database (.github/workflows/go.yml runs neither
-// MySQL nor a sqlite-tagged build), and none of what is under test needs one.
+// The child serves the real probe routes on an http.Server of its own rather
+// than the configured one: this repository's CI has no database
+// (.github/workflows/go.yml runs neither MySQL nor a sqlite-tagged build), and
+// none of what is under test needs one. /ready answers 503 either way - with
+// no database its checks fail - so the assertions below are on the draining
+// answer specifically, not on the status code alone.
 const (
 	childEnv         = "GO_ADMIN_SIGNAL_CHILD"
 	childStuckEnv    = "GO_ADMIN_SIGNAL_CHILD_STUCK"
 	childHangConn    = "GO_ADMIN_SIGNAL_CHILD_HANGCONN"
 	childSlowCleanup = "GO_ADMIN_SIGNAL_CHILD_SLOWCLEANUP"
+	childDrainMS     = "GO_ADMIN_SIGNAL_CHILD_DRAIN_MS"
+	markerAddr       = "CHILD-ADDR"
 	markerReady      = "CHILD-READY"
 	markerSignal     = "CHILD-SIGNAL"
 	markerShutdown   = "CHILD-SHUTDOWN-OK"
 	markerCleanup    = "CHILD-CLEANUP-RAN"
+	markerTook       = "CHILD-TOOK-NS"
 	markerExiting    = "CHILD-EXITING"
+)
+
+// childPingRoute is an ordinary route, registered beside the probes so the
+// window can be checked for what it promises: requests arriving inside it are
+// served, not refused. Refusing them would move the outage earlier instead of
+// avoiding it.
+const childPingRoute = "/signal-test-ping"
+
+var (
+	readyPath  = otherrouter.APIPrefix + otherrouter.ReadyPath
+	healthPath = otherrouter.APIPrefix + otherrouter.HealthPath
+	pingPath   = otherrouter.APIPrefix + childPingRoute
 )
 
 // TestSignalChild is the child process. It is skipped in a normal run.
@@ -42,6 +67,12 @@ func TestSignalChild(t *testing.T) {
 	if os.Getenv(childEnv) != "1" {
 		t.Skip("child process entry point")
 	}
+
+	gin.SetMode(gin.TestMode)
+	engine := gin.New()
+	v1 := engine.Group(otherrouter.APIPrefix)
+	otherrouter.RegisterMonitorRouter(v1)
+	v1.GET(childPingRoute, func(c *gin.Context) { c.String(http.StatusOK, "pong") })
 
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
@@ -54,7 +85,7 @@ func TestSignalChild(t *testing.T) {
 	// finds nothing to wait for and returns immediately.
 	accepted := make(chan struct{}, 1)
 	srv := &http.Server{
-		Handler: http.NewServeMux(),
+		Handler: engine,
 		ConnState: func(_ net.Conn, state http.ConnState) {
 			if state == http.StateNew {
 				select {
@@ -66,9 +97,18 @@ func TestSignalChild(t *testing.T) {
 	}
 	go func() { _ = srv.Serve(ln) }()
 
-	// The budget the child spends, which with nothing set is the one a
-	// shutdown spends today.
+	// The budget the child spends. Nothing here calls bootstrap.SetupConfig, so
+	// with no environment set this is the budget of a deployment that
+	// configures no extend.shutdown section at all.
 	b := defaultBudget()
+	if ms := os.Getenv(childDrainMS); ms != "" {
+		n, err := strconv.Atoi(ms)
+		if err != nil {
+			fmt.Println("drain:", err)
+			os.Exit(4)
+		}
+		b.drain = time.Duration(n) * time.Millisecond
+	}
 
 	// A BeforeExit callback, registered the way a module would. What the tests
 	// below care about is whether it runs at all - after a Shutdown that
@@ -77,8 +117,8 @@ func TestSignalChild(t *testing.T) {
 		switch {
 		case os.Getenv(childStuckEnv) == "1":
 			// Stands in for a cleanup hook that never finishes. The point of
-			// restoring the signal disposition is that a second signal still
-			// reaches the default handler and kills this.
+			// restoring the signal disposition after the drain window is that
+			// a second signal still reaches the default handler and kills this.
 			time.Sleep(2 * time.Minute)
 		case os.Getenv(childSlowCleanup) == "1":
 			// Outlasts the budget on purpose, and does not consult ctx - which
@@ -103,6 +143,7 @@ func TestSignalChild(t *testing.T) {
 	// accident.
 	quit, disarm := armStopSignals()
 
+	fmt.Println(markerAddr, ln.Addr().String())
 	fmt.Println(markerReady)
 	_ = os.Stdout.Sync()
 
@@ -138,7 +179,9 @@ func TestSignalChild(t *testing.T) {
 		b.server = 300 * time.Millisecond
 	}
 
-	serverErr, cleanupErr := gracefulShutdown(srv, disarm, b)
+	started := time.Now()
+	serverErr, cleanupErr := gracefulShutdown(srv, quit, disarm, b)
+	spent := time.Since(started)
 
 	if serverErr != nil {
 		// Deliberately not fatal, and deliberately not a bare return: the
@@ -150,6 +193,7 @@ func TestSignalChild(t *testing.T) {
 	if cleanupErr != nil {
 		fmt.Println("cleanup error:", cleanupErr)
 	}
+	fmt.Println(markerTook, spent.Nanoseconds())
 	fmt.Println(markerExiting)
 	_ = os.Stdout.Sync()
 }
@@ -234,6 +278,134 @@ func await(t *testing.T, lines chan string, want string, d time.Duration) ([]str
 	}
 }
 
+// childAddr waits for the address the child is listening on.
+func childAddr(t *testing.T, lines chan string) string {
+	t.Helper()
+	_, line := await(t, lines, markerAddr, 30*time.Second)
+	fields := strings.Fields(line)
+	return fields[len(fields)-1]
+}
+
+// took reads the nanoseconds gracefulShutdown spent, as the child measured
+// them. Measured inside the child on purpose: the parent's own clock includes
+// process scheduling, which is the noise the tightest assertion here cannot
+// afford.
+func took(t *testing.T, lines chan string, d time.Duration) time.Duration {
+	t.Helper()
+	_, line := await(t, lines, markerTook, d)
+	fields := strings.Fields(line)
+	ns, err := strconv.ParseInt(fields[len(fields)-1], 10, 64)
+	if err != nil {
+		t.Fatalf("unreadable %s line %q: %v", markerTook, line, err)
+	}
+	return time.Duration(ns)
+}
+
+// sample is one answer, or the refusal that replaced it.
+type sample struct {
+	at   time.Time
+	path string
+	// status is zero when the connection could not be made at all, which is
+	// what a closed listener looks like from outside.
+	status   int
+	draining bool
+	// willClose is what the server answered about the connection: the header
+	// it sends is Connection: close, which the transport consumes and reports
+	// here rather than leaving in Response.Header.
+	willClose bool
+}
+
+// probe asks once, on a connection of its own.
+//
+// A new transport per request, because a connection opened before the signal
+// can still be served after the listener is closed: reusing one would let this
+// test pass against a shutdown that had already broken the listener. Keep-alive
+// is left enabled so the server's own Connection: close is observable - a
+// client that asked for close would get that header back either way, and the
+// assertion would prove nothing.
+func probe(addr, path string) sample {
+	tr := &http.Transport{}
+	defer tr.CloseIdleConnections()
+	c := &http.Client{Transport: tr, Timeout: 3 * time.Second}
+
+	s := sample{at: time.Now(), path: path}
+	resp, err := c.Get("http://" + addr + path)
+	if err != nil {
+		return s
+	}
+	defer func() { _ = resp.Body.Close() }()
+	body, _ := io.ReadAll(resp.Body)
+	s.status = resp.StatusCode
+	s.willClose = resp.Close
+	s.draining = strings.Contains(string(body), `"status":"draining"`)
+	return s
+}
+
+// watcher polls the child until it stops accepting connections, keeping every
+// answer.
+type watcher struct {
+	mu      sync.Mutex
+	samples []sample
+	done    chan struct{}
+}
+
+func watch(addr string, paths ...string) *watcher {
+	w := &watcher{done: make(chan struct{})}
+	go func() {
+		defer close(w.done)
+		for {
+			refused := false
+			for _, p := range paths {
+				s := probe(addr, p)
+				w.mu.Lock()
+				w.samples = append(w.samples, s)
+				w.mu.Unlock()
+				if s.status == 0 {
+					refused = true
+				}
+			}
+			if refused {
+				return
+			}
+			time.Sleep(20 * time.Millisecond)
+		}
+	}()
+	return w
+}
+
+// sawDraining reports whether /ready has answered "draining" yet.
+func (w *watcher) sawDraining() bool {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	for _, s := range w.samples {
+		if s.path == readyPath && s.draining {
+			return true
+		}
+	}
+	return false
+}
+
+func (w *watcher) wait(t *testing.T, d time.Duration) []sample {
+	t.Helper()
+	select {
+	case <-w.done:
+	case <-time.After(d):
+		t.Fatal("the child never stopped accepting connections")
+	}
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.samples
+}
+
+func describe(samples []sample) string {
+	var b strings.Builder
+	for _, s := range samples {
+		fmt.Fprintf(&b, "  %s %s -> %d draining=%v willClose=%v\n",
+			s.at.Format("15:04:05.000"), s.path, s.status, s.draining, s.willClose)
+	}
+	return b.String()
+}
+
 // Acceptance 19. Registering only os.Interrupt meant SIGTERM - the signal
 // `docker stop`, Kubernetes and systemd all send - terminated the process
 // before any of the shutdown path ran. Both must now reach it.
@@ -269,9 +441,11 @@ func TestBothSignalsRunTheShutdownPath(t *testing.T) {
 // once SIGTERM is registered, a shutdown that hangs could not be interrupted by
 // anything short of SIGKILL.
 //
-// The hang is a cleanup callback that never returns, which is where a shutdown
-// actually hangs, and it is reached through gracefulShutdown - so this also
-// pins where the disposition is restored.
+// The hang is now a cleanup callback that never returns, which is where a
+// shutdown actually hangs, and it is reached through gracefulShutdown - so this
+// also pins where the disposition is restored. Restore it before the drain
+// window and the window itself becomes the interruptible part; restore it never
+// and this test hangs.
 func TestASecondSignalStillKillsAStuckShutdown(t *testing.T) {
 	cmd, lines := startChild(t, true)
 	await(t, lines, markerReady, 30*time.Second)
@@ -283,9 +457,11 @@ func TestASecondSignalStillKillsAStuckShutdown(t *testing.T) {
 
 	// The child is now on its way into a cleanup that will not finish on its
 	// own. Signalled repeatedly rather than once: the marker is printed just
-	// before gracefulShutdown is entered, so a single signal sent immediately
-	// after it can still land in the buffered channel and be dropped. Which of
-	// them does the killing is not the assertion; that one of them can is.
+	// before gracefulShutdown is entered, and the disposition is not restored
+	// until the drain window is over - zero seconds here, but not zero
+	// instructions - so a single signal sent immediately after the marker can
+	// still land in the buffered channel and be dropped. Which of them does
+	// the killing is not the assertion; that one of them can is.
 	done := make(chan error, 1)
 	go func() { done <- cmd.Wait() }()
 
@@ -384,5 +560,180 @@ func TestACleanupThatOutlastsItsBudgetIsAbandonedNotAwaited(t *testing.T) {
 	}
 	if err := cmd.Wait(); err != nil {
 		t.Fatalf("child exited with %v, want a clean exit despite the abandoned callback", err)
+	}
+}
+
+// The core acceptance: with a drain window configured, something outside the
+// process can observe that this instance is draining, on a connection it opens
+// after the signal, and can still be served while it does.
+//
+// Two windows rather than one. A single value proves only that something takes
+// that long, which a hard-coded sleep anywhere in the sequence would satisfy;
+// two say the wait is the configured one.
+//
+// What each answer is for:
+//
+//   - /ready reporting "draining" is the window being observable at all. The
+//     status code alone would not say it: with no database configured the
+//     probe's own checks fail and 503 is also the answer before the signal.
+//   - The server refusing to keep those connections alive is the window being
+//     useful. It keeps them alive until Shutdown sets shuttingDown(), so
+//     without switching keep-alive off here a balancer's pool would sit
+//     untouched for the whole window and be cut at the end of it anyway. The
+//     header saying so is Connection: close; the transport consumes it and
+//     reports it as Response.Close, which is what a sample records.
+//   - /health staying 200 is the window not asking to be restarted, and the
+//     ordinary route staying 200 is the window not refusing work. Draining is
+//     "stop sending me new work", not "reject what arrives".
+func TestTheDrainWindowIsObservableWhileStillServing(t *testing.T) {
+	for _, drain := range []time.Duration{300 * time.Millisecond, 1200 * time.Millisecond} {
+		t.Run(drain.String(), func(t *testing.T) {
+			cmd, lines := startChild(t, false,
+				fmt.Sprintf("%s=%d", childDrainMS, drain.Milliseconds()))
+			addr := childAddr(t, lines)
+			await(t, lines, markerReady, 30*time.Second)
+
+			w := watch(addr, readyPath, healthPath, pingPath)
+			// Long enough for a round of answers from a server that is not yet
+			// draining, which is what the keep-alive assertion below compares
+			// against.
+			time.Sleep(150 * time.Millisecond)
+
+			signalAt := time.Now()
+			if err := cmd.Process.Signal(syscall.SIGTERM); err != nil {
+				t.Fatalf("signal: %v", err)
+			}
+
+			samples := w.wait(t, drain+30*time.Second)
+			spent := took(t, lines, 10*time.Second)
+			await(t, lines, markerExiting, 10*time.Second)
+
+			if spent < drain {
+				t.Errorf("the shutdown took %s, want at least the %s window", spent, drain)
+			}
+
+			var refusedAt = -1
+			for i, s := range samples {
+				if s.status == 0 {
+					refusedAt = i
+					break
+				}
+			}
+			if refusedAt < 0 {
+				t.Fatalf("the child never stopped accepting; saw:\n%s", describe(samples))
+			}
+
+			var keptAliveBefore, drainingInside, closedInside bool
+			for _, s := range samples[:refusedAt] {
+				switch s.path {
+				case readyPath:
+					if s.at.Before(signalAt) && !s.draining && !s.willClose {
+						keptAliveBefore = true
+					}
+					if s.at.After(signalAt) && s.draining {
+						drainingInside = true
+						if s.willClose {
+							closedInside = true
+						}
+					}
+				case healthPath, pingPath:
+					if s.status != http.StatusOK {
+						t.Errorf("%s answered %d before the listener closed, want 200;\n%s",
+							s.path, s.status, describe(samples))
+					}
+				}
+			}
+
+			if !keptAliveBefore {
+				t.Fatalf("no answer before the signal kept the connection alive, so the header assertion below proves nothing;\n%s",
+					describe(samples))
+			}
+			if !drainingInside {
+				t.Errorf("no answer inside the window reported draining; the flip and the closed listener were not far enough apart to observe;\n%s",
+					describe(samples))
+			}
+			if !closedInside {
+				t.Errorf("answers inside the window still kept the connection alive, so a pooled connection survives the whole window and is cut at the end of it anyway;\n%s",
+					describe(samples))
+			}
+
+			if err := cmd.Wait(); err != nil {
+				t.Fatalf("child exited with %v, want a clean exit", err)
+			}
+		})
+	}
+}
+
+// The default has to be no window at all: a process that configures no
+// extend.shutdown section must shut down the way it did before the section
+// existed.
+//
+// Asserted as a sequence rather than as a duration. How long a shutdown takes
+// is decided by how much the cleanup callbacks have to do, so "as fast as
+// before" is not falsifiable; "nothing was inserted between the signal and the
+// listener closing" is.
+func TestAnUnconfiguredShutdownAddsNoWindow(t *testing.T) {
+	cmd, lines := startChild(t, false)
+	await(t, lines, markerReady, 30*time.Second)
+
+	if err := cmd.Process.Signal(syscall.SIGTERM); err != nil {
+		t.Fatalf("signal: %v", err)
+	}
+	await(t, lines, markerSignal, 10*time.Second)
+
+	spent := took(t, lines, 10*time.Second)
+	if spent > 100*time.Millisecond {
+		t.Errorf("an unconfigured shutdown spent %s between the signal and exiting; "+
+			"with no drain window and no cleanup callbacks it must be immediate", spent)
+	}
+
+	if err := cmd.Wait(); err != nil {
+		t.Fatalf("child exited with %v, want a clean exit", err)
+	}
+}
+
+// A second signal during the window ends it early rather than killing the
+// process. Somebody sending another kill wants this over with sooner, and the
+// answer to that is to stop draining - not to skip the cleanup, which is what
+// the default disposition would do.
+//
+// This is the pair to TestASecondSignalStillKillsAStuckShutdown: the escape
+// hatch has to be closed for the length of the window and open after it.
+func TestASecondSignalEndsTheDrainWindowEarly(t *testing.T) {
+	// Long enough that the shutdown cannot plausibly have taken this long on
+	// its own, short enough that the test does not sit out the whole window
+	// when the early exit is missing - it fails on the reported duration
+	// instead of on a timeout, which says which of the two broke.
+	const window = 10 * time.Second
+	cmd, lines := startChild(t, false,
+		fmt.Sprintf("%s=%d", childDrainMS, window.Milliseconds()))
+	addr := childAddr(t, lines)
+	await(t, lines, markerReady, 30*time.Second)
+
+	w := watch(addr, readyPath)
+	if err := cmd.Process.Signal(syscall.SIGTERM); err != nil {
+		t.Fatalf("first signal: %v", err)
+	}
+
+	deadline := time.Now().Add(15 * time.Second)
+	for !w.sawDraining() {
+		if time.Now().After(deadline) {
+			t.Fatal("the child never reported draining, so the second signal below would not land inside the window")
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	if err := cmd.Process.Signal(syscall.SIGTERM); err != nil {
+		t.Fatalf("second signal: %v", err)
+	}
+
+	spent := took(t, lines, window+20*time.Second)
+	if spent >= window {
+		t.Errorf("the window ran its full %s despite a second signal (%s); the signal was ignored", window, spent)
+	}
+	await(t, lines, markerExiting, 10*time.Second)
+
+	if err := cmd.Wait(); err != nil {
+		t.Fatalf("child exited with %v; a second signal inside the window must end the window, not the process", err)
 	}
 }

--- a/cmd/api/signal_test.go
+++ b/cmd/api/signal_test.go
@@ -17,8 +17,10 @@ import (
 
 // The signal path cannot be exercised in-process: delivering a signal to the
 // test binary would race with the test framework, and the disposition changes
-// are global. So the test re-executes itself as a child, and the child runs the
-// same armStopSignals / shutdownServer the server does.
+// are global. So the test re-executes itself as a child, and the child runs
+// gracefulShutdown - the same function run() runs, not a second copy of the
+// sequence. A test that reproduces a sequence asserts against its own copy and
+// stays green while the sequence it was written for regresses.
 //
 // The child deliberately serves an empty http.Server rather than the real one:
 // this repository's CI has no database (.github/workflows/go.yml runs neither
@@ -64,22 +66,34 @@ func TestSignalChild(t *testing.T) {
 	}
 	go func() { _ = srv.Serve(ln) }()
 
+	// The budget the child spends, which with nothing set is the one a
+	// shutdown spends today.
+	b := defaultBudget()
+
 	// A BeforeExit callback, registered the way a module would. What the tests
 	// below care about is whether it runs at all - after a Shutdown that
 	// failed, and after its own budget has been spent.
-	cleanupBudget := cleanupTimeout
 	sdk.Runtime.SetShutdown(func(ctx context.Context) {
-		if os.Getenv(childSlowCleanup) == "1" {
-			// Outlasts the budget on purpose, and does not consult ctx -
-			// which is the case the contract is explicit about: what the
-			// context bounds is the wait, not the work.
+		switch {
+		case os.Getenv(childStuckEnv) == "1":
+			// Stands in for a cleanup hook that never finishes. The point of
+			// restoring the signal disposition is that a second signal still
+			// reaches the default handler and kills this.
+			time.Sleep(2 * time.Minute)
+		case os.Getenv(childSlowCleanup) == "1":
+			// Outlasts the budget on purpose, and does not consult ctx - which
+			// is the case the contract is explicit about: what the context
+			// bounds is the wait, not the work.
 			time.Sleep(2 * time.Second)
 		}
 		fmt.Println(markerCleanup)
-		os.Stdout.Sync()
+		_ = os.Stdout.Sync()
 	})
-	if os.Getenv(childSlowCleanup) == "1" {
-		cleanupBudget = 300 * time.Millisecond
+	switch {
+	case os.Getenv(childStuckEnv) == "1":
+		b.cleanup = 2 * time.Minute
+	case os.Getenv(childSlowCleanup) == "1":
+		b.cleanup = 300 * time.Millisecond
 	}
 
 	// Arm before announcing readiness. Doing it the other way round leaves a
@@ -90,21 +104,12 @@ func TestSignalChild(t *testing.T) {
 	quit, disarm := armStopSignals()
 
 	fmt.Println(markerReady)
-	os.Stdout.Sync()
+	_ = os.Stdout.Sync()
 
 	sig := <-quit
-	disarm()
 	fmt.Println(markerSignal, sig)
-	os.Stdout.Sync()
+	_ = os.Stdout.Sync()
 
-	if os.Getenv(childStuckEnv) == "1" {
-		// Stand in for a cleanup hook that never finishes. The point of
-		// restoring the signal disposition is that a second signal still
-		// reaches the default handler and kills this.
-		time.Sleep(2 * time.Minute)
-	}
-
-	timeout := shutdownTimeout
 	if os.Getenv(childHangConn) == "1" {
 		// Dialled here, not at start-up. net/http stops counting a StateNew
 		// connection against Shutdown once it is more than five seconds old,
@@ -130,27 +135,26 @@ func TestSignalChild(t *testing.T) {
 		// only treats a StateNew connection as idle once it is more than five
 		// seconds old. A short budget makes the timeout deterministic without
 		// waiting out the real one.
-		timeout = 300 * time.Millisecond
+		b.server = 300 * time.Millisecond
 	}
 
-	sdk.Runtime.BeginShutdown()
+	serverErr, cleanupErr := gracefulShutdown(srv, disarm, b)
 
-	if err := shutdownServer(srv, timeout); err != nil {
+	if serverErr != nil {
 		// Deliberately not fatal, and deliberately not a bare return: the
 		// point is that whatever follows still runs.
-		fmt.Println("shutdown error:", err)
+		fmt.Println("shutdown error:", serverErr)
 	} else {
 		fmt.Println(markerShutdown)
 	}
-
-	if err := runShutdownHooks(cleanupBudget); err != nil {
-		fmt.Println("cleanup error:", err)
+	if cleanupErr != nil {
+		fmt.Println("cleanup error:", cleanupErr)
 	}
 	fmt.Println(markerExiting)
-	os.Stdout.Sync()
+	_ = os.Stdout.Sync()
 }
 
-func startChild(t *testing.T, stuck bool, extraEnv ...string) (*exec.Cmd, *os.File, chan string) {
+func startChild(t *testing.T, stuck bool, extraEnv ...string) (*exec.Cmd, chan string) {
 	t.Helper()
 
 	r, w, err := os.Pipe()
@@ -170,7 +174,7 @@ func startChild(t *testing.T, stuck bool, extraEnv ...string) (*exec.Cmd, *os.Fi
 	}
 	_ = w.Close()
 
-	lines := make(chan string, 64)
+	lines := make(chan string, 256)
 	go func() {
 		defer close(lines)
 		buf := make([]byte, 4096)
@@ -204,12 +208,13 @@ func startChild(t *testing.T, stuck bool, extraEnv ...string) (*exec.Cmd, *os.Fi
 		_, _ = cmd.Process.Wait()
 		_ = r.Close()
 	})
-	return cmd, r, lines
+	return cmd, lines
 }
 
 // await drains lines until one contains want, or the deadline passes. It
-// returns everything it saw, so a failure says what the child actually did.
-func await(t *testing.T, lines chan string, want string, d time.Duration) []string {
+// returns everything it saw, so a failure says what the child actually did,
+// and the matching line, so a marker can carry a value.
+func await(t *testing.T, lines chan string, want string, d time.Duration) ([]string, string) {
 	t.Helper()
 	var seen []string
 	deadline := time.After(d)
@@ -221,7 +226,7 @@ func await(t *testing.T, lines chan string, want string, d time.Duration) []stri
 			}
 			seen = append(seen, l)
 			if strings.Contains(l, want) {
-				return seen
+				return seen, l
 			}
 		case <-deadline:
 			t.Fatalf("timed out waiting for %q; saw:\n%s", want, strings.Join(seen, "\n"))
@@ -241,7 +246,7 @@ func TestBothSignalsRunTheShutdownPath(t *testing.T) {
 		{"SIGTERM", syscall.SIGTERM},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			cmd, _, lines := startChild(t, false)
+			cmd, lines := startChild(t, false)
 			await(t, lines, markerReady, 30*time.Second)
 
 			if err := cmd.Process.Signal(tc.sig); err != nil {
@@ -263,8 +268,12 @@ func TestBothSignalsRunTheShutdownPath(t *testing.T) {
 // without restoring the disposition a second signal only refills the buffer:
 // once SIGTERM is registered, a shutdown that hangs could not be interrupted by
 // anything short of SIGKILL.
+//
+// The hang is a cleanup callback that never returns, which is where a shutdown
+// actually hangs, and it is reached through gracefulShutdown - so this also
+// pins where the disposition is restored.
 func TestASecondSignalStillKillsAStuckShutdown(t *testing.T) {
-	cmd, _, lines := startChild(t, true)
+	cmd, lines := startChild(t, true)
 	await(t, lines, markerReady, 30*time.Second)
 
 	if err := cmd.Process.Signal(syscall.SIGTERM); err != nil {
@@ -272,21 +281,31 @@ func TestASecondSignalStillKillsAStuckShutdown(t *testing.T) {
 	}
 	await(t, lines, markerSignal, 10*time.Second)
 
-	// The child is now inside a cleanup that will not finish on its own.
-	if err := cmd.Process.Signal(syscall.SIGTERM); err != nil {
-		t.Fatalf("second signal: %v", err)
-	}
-
+	// The child is now on its way into a cleanup that will not finish on its
+	// own. Signalled repeatedly rather than once: the marker is printed just
+	// before gracefulShutdown is entered, so a single signal sent immediately
+	// after it can still land in the buffered channel and be dropped. Which of
+	// them does the killing is not the assertion; that one of them can is.
 	done := make(chan error, 1)
 	go func() { done <- cmd.Wait() }()
 
-	select {
-	case err := <-done:
-		if err == nil {
-			t.Fatal("child exited cleanly; it was supposed to be killed by the second signal")
+	retry := time.NewTicker(200 * time.Millisecond)
+	defer retry.Stop()
+	deadline := time.After(15 * time.Second)
+	for {
+		select {
+		case err := <-done:
+			if err == nil {
+				t.Fatal("child exited cleanly; it was supposed to be killed by the second signal")
+			}
+			return
+		case <-retry.C:
+			if err := cmd.Process.Signal(syscall.SIGTERM); err != nil {
+				t.Fatalf("second signal: %v", err)
+			}
+		case <-deadline:
+			t.Fatal("the second signal did not kill a stuck shutdown - the escape hatch is gone")
 		}
-	case <-time.After(15 * time.Second):
-		t.Fatal("the second signal did not kill a stuck shutdown - the escape hatch is gone")
 	}
 }
 
@@ -295,7 +314,7 @@ func TestASecondSignalStillKillsAStuckShutdown(t *testing.T) {
 // unconditional os.Exit(1). Everything after it, which is where the cleanup
 // hooks will hang, never ran. A failed Shutdown must not end the process.
 func TestShutdownTimeoutDoesNotStopWhatFollows(t *testing.T) {
-	cmd, _, lines := startChild(t, false, childHangConn+"=1")
+	cmd, lines := startChild(t, false, childHangConn+"=1")
 	await(t, lines, markerReady, 30*time.Second)
 
 	if err := cmd.Process.Signal(syscall.SIGTERM); err != nil {
@@ -303,7 +322,7 @@ func TestShutdownTimeoutDoesNotStopWhatFollows(t *testing.T) {
 	}
 	await(t, lines, markerSignal, 10*time.Second)
 
-	seen := await(t, lines, markerExiting, 20*time.Second)
+	seen, _ := await(t, lines, markerExiting, 20*time.Second)
 
 	var timedOut bool
 	for _, l := range seen {
@@ -336,7 +355,7 @@ func TestShutdownTimeoutDoesNotStopWhatFollows(t *testing.T) {
 // the contract that is easy to get backwards - the context bounds the wait, not
 // the work, because Go cannot cancel a function that does not check for it.
 func TestACleanupThatOutlastsItsBudgetIsAbandonedNotAwaited(t *testing.T) {
-	cmd, _, lines := startChild(t, false, childSlowCleanup+"=1")
+	cmd, lines := startChild(t, false, childSlowCleanup+"=1")
 	await(t, lines, markerReady, 30*time.Second)
 
 	if err := cmd.Process.Signal(syscall.SIGTERM); err != nil {
@@ -347,7 +366,7 @@ func TestACleanupThatOutlastsItsBudgetIsAbandonedNotAwaited(t *testing.T) {
 	// The budget is 300ms and the callback sleeps two seconds. If RunShutdown
 	// waited for it, this marker would not arrive for two seconds; the one
 	// second here is what makes "abandoned, not awaited" the thing asserted.
-	seen := await(t, lines, markerExiting, 1*time.Second)
+	seen, _ := await(t, lines, markerExiting, 1*time.Second)
 
 	var reported bool
 	for _, l := range seen {

--- a/common/health/health.go
+++ b/common/health/health.go
@@ -13,18 +13,26 @@
 //     because of the life-cycle phases - it fails as soon as shutdown begins,
 //     before the server stops accepting.
 //
-// # What the draining answer is worth today
+// # What the draining answer is worth
 //
-// It is an answer that can be read, not one a balancer acts on. Nothing waits
-// between the flip and the shutdown, and a poller on a multi-second interval
-// never observes it. On Kubernetes the endpoint is withdrawn when the Pod
-// receives a deletionTimestamp, concurrently with SIGTERM and whatever the
-// probe returns; the probe result is not what removes it.
+// Order alone does not produce a window. Answering before the server stops
+// accepting is the right order - the reverse reports the state after the
+// connections are already cut - but with nothing between the two they are
+// microseconds apart, and a poller on a multi-second interval never sees the
+// 503.
 //
-// Answering before the server stops accepting is still the right order - the
-// reverse reports the state after the connections are already cut - but order
-// alone does not produce a window. That needs a configured delay between the
-// two, which this process does not have.
+// The delay between them is extend.shutdown.drain, which is zero unless it is
+// configured. On the shipped defaults this is therefore still an answer that
+// can be read rather than one anything acts on; a deployment that sets a drain
+// window is the one that gets a window to act in.
+//
+// What acts on it depends on who does the removing. A load balancer that polls
+// /ready takes this instance out when it reads the 503, and the window has to
+// cover its check interval times its failure threshold, plus however long the
+// removal takes to apply. On Kubernetes the endpoint is withdrawn when the Pod
+// receives a deletionTimestamp, concurrently with SIGTERM and regardless of
+// what the probe returns - there the window covers the delay in that removal
+// reaching every node, and the 503 is what makes the state observable.
 package health
 
 import (

--- a/common/health/health_test.go
+++ b/common/health/health_test.go
@@ -187,9 +187,12 @@ func TestEveryDependencyIsReportedEvenWithNothingConfigured(t *testing.T) {
 	}
 }
 
-// Draining is what makes the shutdown graceful from the outside: it has to be
-// observable before the server stops accepting, or the load balancer learns
-// about the shutdown by having its connections cut.
+// BeginDraining sets the flag and Draining reports it, before anything else is
+// taken apart. That is the whole of what can be checked from inside the
+// process: whether anyone outside gets to read it depends on
+// extend.shutdown.drain, which is zero unless it is configured, and on who is
+// routing traffic here - the package comment has both. The subprocess tests in
+// cmd/api are where a reader on the other end of a socket sees the 503.
 func TestDrainingIsObservableOnceItBegins(t *testing.T) {
 	previous := draining.Load()
 	t.Cleanup(func() { draining.Store(previous) })

--- a/config/extend.go
+++ b/config/extend.go
@@ -1,5 +1,10 @@
 package config
 
+import (
+	"fmt"
+	"strings"
+)
+
 var ExtConfig Extend
 
 // Extend 扩展配置
@@ -13,6 +18,7 @@ type Extend struct {
 	AMap      AMap // 这里配置对应配置文件的结构即可
 	FileStore FileStore
 	RateLimit RateLimit
+	Shutdown  Shutdown
 }
 
 // DefaultInboundQPS is the limit applied when nothing is configured. It is the
@@ -71,4 +77,80 @@ type ObjectStore struct {
 // Configured reports whether enough was filled in to attempt a connection.
 func (o ObjectStore) Configured() bool {
 	return o.Endpoint != "" && o.AccessKeyID != "" && o.AccessKeySecret != "" && o.BucketName != ""
+}
+
+// Default budgets for a graceful shutdown, in seconds. Each applies to the
+// matching field of extend.shutdown when that field is absent, and together
+// they are what the process spent before the section existed - so a deployment
+// that configures nothing keeps the shutdown it already had.
+const (
+	DefaultServerSeconds  = 5
+	DefaultCleanupSeconds = 3
+)
+
+// Shutdown is how long a graceful shutdown may spend, stage by stage.
+//
+//	extend:
+//	  shutdown:
+//	    server: 5
+//	    cleanup: 3
+//
+// Every field is a pointer for the reason RateLimit.InboundQPS is: nil means
+// "not configured" and takes the default, while a value that was written down
+// is taken literally, zero included. Without that separation `server: 0` - do
+// not wait for in-flight requests, which is a reasonable thing to ask under a
+// very short grace period - could not be said at all.
+type Shutdown struct {
+	// Server is how long the server waits for in-flight requests once the
+	// listener is closed.
+	Server *int
+	// Cleanup is how long the BeforeExit callbacks get after that.
+	Cleanup *int
+}
+
+// ShutdownBudget is what a shutdown will actually spend, in seconds, after the
+// fallbacks have been applied.
+type ShutdownBudget struct {
+	Server  int
+	Cleanup int
+}
+
+// Budget resolves the configured section into the values that will be spent.
+//
+// A negative is refused rather than corrected. A wait cannot be negative, so
+// there is no reading of one to honour, and quietly turning it into zero would
+// be the failure this whole section exists to remove: written down, accepted,
+// and not what happens. It is returned as an error rather than reported here
+// so that the rule can be checked without ending the process.
+func (s Shutdown) Budget() (ShutdownBudget, error) {
+	var negative []string
+	for _, f := range []struct {
+		name  string
+		value *int
+	}{
+		{"server", s.Server},
+		{"cleanup", s.Cleanup},
+	} {
+		if f.value != nil && *f.value < 0 {
+			negative = append(negative, fmt.Sprintf("%s: %d", f.name, *f.value))
+		}
+	}
+	if len(negative) > 0 {
+		return ShutdownBudget{}, fmt.Errorf(
+			"extend.shutdown was given a negative number of seconds (%s); "+
+				"a wait cannot be negative, and 0 is how to say \"do not wait\"",
+			strings.Join(negative, ", "))
+	}
+
+	return ShutdownBudget{
+		Server:  budgetSeconds(s.Server, DefaultServerSeconds),
+		Cleanup: budgetSeconds(s.Cleanup, DefaultCleanupSeconds),
+	}, nil
+}
+
+func budgetSeconds(configured *int, fallback int) int {
+	if configured != nil {
+		return *configured
+	}
+	return fallback
 }

--- a/config/extend.go
+++ b/config/extend.go
@@ -104,6 +104,7 @@ const (
 //	    drain: 0
 //	    server: 5
 //	    cleanup: 3
+//	    grace: 30
 //
 // Every field is a pointer for the reason RateLimit.InboundQPS is: nil means
 // "not configured" and takes the default, while a value that was written down
@@ -128,6 +129,13 @@ type Shutdown struct {
 	Server *int
 	// Cleanup is how long the BeforeExit callbacks get after that.
 	Cleanup *int
+	// Grace is the stop grace period the orchestrator gives this process -
+	// `docker stop --timeout`, or terminationGracePeriodSeconds. Nothing reads
+	// it during a shutdown; it exists so start-up can say whether the budget
+	// fits inside it. Absent means no comparison is made, because the
+	// reference values differ threefold between runtimes and a fixed threshold
+	// would warn about configurations that are correct.
+	Grace *int
 }
 
 // ShutdownBudget is what a shutdown will actually spend, in seconds, after the
@@ -136,6 +144,8 @@ type ShutdownBudget struct {
 	Drain   int
 	Server  int
 	Cleanup int
+	// Grace is zero when extend.shutdown.grace was not configured.
+	Grace int
 }
 
 // Budget resolves the configured section into the values that will be spent.
@@ -154,6 +164,7 @@ func (s Shutdown) Budget() (ShutdownBudget, error) {
 		{"drain", s.Drain},
 		{"server", s.Server},
 		{"cleanup", s.Cleanup},
+		{"grace", s.Grace},
 	} {
 		if f.value != nil && *f.value < 0 {
 			negative = append(negative, fmt.Sprintf("%s: %d", f.name, *f.value))
@@ -170,6 +181,7 @@ func (s Shutdown) Budget() (ShutdownBudget, error) {
 		Drain:   budgetSeconds(s.Drain, DefaultDrainSeconds),
 		Server:  budgetSeconds(s.Server, DefaultServerSeconds),
 		Cleanup: budgetSeconds(s.Cleanup, DefaultCleanupSeconds),
+		Grace:   budgetSeconds(s.Grace, 0),
 	}, nil
 }
 
@@ -178,4 +190,21 @@ func budgetSeconds(configured *int, fallback int) int {
 		return *configured
 	}
 	return fallback
+}
+
+// Total is the whole of the shutdown, since the three stages run one after the
+// other.
+func (b ShutdownBudget) Total() int { return b.Drain + b.Server + b.Cleanup }
+
+// Overrun reports how many seconds have to be found for the budget to fit
+// inside the configured grace period. It is zero when no grace period was
+// configured and when the budget already fits.
+//
+// Fitting means strictly less: the grace period is when SIGKILL is sent, so a
+// budget that ends exactly then leaves the last callback no time to return.
+func (b ShutdownBudget) Overrun() int {
+	if b.Grace <= 0 || b.Total() < b.Grace {
+		return 0
+	}
+	return b.Total() - b.Grace + 1
 }

--- a/config/extend.go
+++ b/config/extend.go
@@ -83,7 +83,16 @@ func (o ObjectStore) Configured() bool {
 // matching field of extend.shutdown when that field is absent, and together
 // they are what the process spent before the section existed - so a deployment
 // that configures nothing keeps the shutdown it already had.
+//
+// The drain default is zero deliberately. The three budgets are spent one
+// after the other, and once their sum reaches the orchestrator's stop grace
+// period the process is killed part-way through its cleanup callbacks, which
+// is worse than not draining at all. `docker stop` allows ten seconds by
+// default and 5+3 already leaves little room, so a non-zero default here would
+// slow down every existing shutdown to buy something only a load balancer that
+// polls /ready can collect.
 const (
+	DefaultDrainSeconds   = 0
 	DefaultServerSeconds  = 5
 	DefaultCleanupSeconds = 3
 )
@@ -92,6 +101,7 @@ const (
 //
 //	extend:
 //	  shutdown:
+//	    drain: 0
 //	    server: 5
 //	    cleanup: 3
 //
@@ -99,8 +109,20 @@ const (
 // "not configured" and takes the default, while a value that was written down
 // is taken literally, zero included. Without that separation `server: 0` - do
 // not wait for in-flight requests, which is a reasonable thing to ask under a
-// very short grace period - could not be said at all.
+// very short grace period - could not be said at all, and `drain: 0` would
+// have to mean something different from `server: 0` in the same section.
 type Shutdown struct {
+	// Drain is how long to keep serving normally after a stop signal arrives.
+	// Throughout it /ready answers 503 and keep-alive is switched off, which
+	// is what gives whatever routes traffic here time to stop routing it
+	// before the listener closes. Zero is no window: the readiness flip and
+	// the listener closing are then microseconds apart and nothing observes
+	// the first.
+	//
+	// What the window is worth depends on who does the removing and on what
+	// basis; the package comment in common/health has the two cases, and they
+	// do not want the same value.
+	Drain *int
 	// Server is how long the server waits for in-flight requests once the
 	// listener is closed.
 	Server *int
@@ -111,6 +133,7 @@ type Shutdown struct {
 // ShutdownBudget is what a shutdown will actually spend, in seconds, after the
 // fallbacks have been applied.
 type ShutdownBudget struct {
+	Drain   int
 	Server  int
 	Cleanup int
 }
@@ -128,6 +151,7 @@ func (s Shutdown) Budget() (ShutdownBudget, error) {
 		name  string
 		value *int
 	}{
+		{"drain", s.Drain},
 		{"server", s.Server},
 		{"cleanup", s.Cleanup},
 	} {
@@ -143,6 +167,7 @@ func (s Shutdown) Budget() (ShutdownBudget, error) {
 	}
 
 	return ShutdownBudget{
+		Drain:   budgetSeconds(s.Drain, DefaultDrainSeconds),
 		Server:  budgetSeconds(s.Server, DefaultServerSeconds),
 		Cleanup: budgetSeconds(s.Cleanup, DefaultCleanupSeconds),
 	}, nil

--- a/config/extend_test.go
+++ b/config/extend_test.go
@@ -1,6 +1,9 @@
 package config
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 func TestObjectStoreConfigured(t *testing.T) {
 	if (ObjectStore{}).Configured() {
@@ -30,5 +33,98 @@ func TestRateLimitThreshold(t *testing.T) {
 	custom := 1500.0
 	if got := (RateLimit{InboundQPS: &custom}).Threshold(); got != custom {
 		t.Errorf("configured limit = %v, want %v", got, custom)
+	}
+}
+
+func ptr(v int) *int { return &v }
+
+// The zero-value rule is the one the section would otherwise need a paragraph
+// of documentation to survive: nil takes the default, a number that was
+// written down is spent literally. A `server: 0` that quietly became five
+// seconds would be configuration accepted and not applied.
+func TestShutdownBudgetFallbacks(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		in   Shutdown
+		want ShutdownBudget
+	}{
+		{
+			// What an existing settings.yml hits after an upgrade: no
+			// extend.shutdown section at all, and therefore the shutdown it
+			// already had.
+			name: "nothing configured",
+			in:   Shutdown{},
+			want: ShutdownBudget{Server: 5, Cleanup: 3},
+		},
+		{
+			name: "both configured",
+			in:   Shutdown{Server: ptr(8), Cleanup: ptr(4)},
+			want: ShutdownBudget{Server: 8, Cleanup: 4},
+		},
+		{
+			// The case a plain int could not express: do not wait for
+			// in-flight requests, which is a reasonable thing to ask when the
+			// grace period is very short.
+			name: "explicit zeros are spent, not replaced",
+			in:   Shutdown{Server: ptr(0), Cleanup: ptr(0)},
+			want: ShutdownBudget{Server: 0, Cleanup: 0},
+		},
+		{
+			name: "one field configured, the rest default",
+			in:   Shutdown{Cleanup: ptr(15)},
+			want: ShutdownBudget{Server: 5, Cleanup: 15},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := tc.in.Budget()
+			if err != nil {
+				t.Fatalf("Budget() = %v", err)
+			}
+			if got != tc.want {
+				t.Errorf("Budget() = %+v, want %+v", got, tc.want)
+			}
+		})
+	}
+}
+
+// A negative is refused, not corrected. Turning it into zero would be the
+// failure this section exists to remove - written down, accepted, and not what
+// happens - and there is no reading of a negative wait to honour.
+//
+// The last row is what makes the others mean anything: an implementation that
+// refused every value would pass them all.
+func TestShutdownBudgetRefusesNegativeSeconds(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		in      Shutdown
+		wantErr bool
+	}{
+		{name: "negative server", in: Shutdown{Server: ptr(-1)}, wantErr: true},
+		{name: "negative cleanup", in: Shutdown{Cleanup: ptr(-1)}, wantErr: true},
+		{name: "explicit zeros are not negative", in: Shutdown{Server: ptr(0), Cleanup: ptr(0)}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := tc.in.Budget()
+			if tc.wantErr && err == nil {
+				t.Fatal("Budget() accepted a negative number of seconds")
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("Budget() = %v, want the zeros taken literally", err)
+			}
+		})
+	}
+}
+
+// The message has to name every field that is wrong, not the first one: a
+// caller who fixes one and gets the same error back learns to distrust it.
+func TestShutdownBudgetNamesEveryNegativeField(t *testing.T) {
+	_, err := Shutdown{Server: ptr(-30), Cleanup: ptr(-3)}.Budget()
+	if err == nil {
+		t.Fatal("Budget() accepted two negative values")
+	}
+	for _, name := range []string{"server", "cleanup"} {
+		if !strings.Contains(err.Error(), name) {
+			t.Errorf("%q does not name %s", err, name)
+		}
 	}
 }

--- a/config/extend_test.go
+++ b/config/extend_test.go
@@ -38,10 +38,11 @@ func TestRateLimitThreshold(t *testing.T) {
 
 func ptr(v int) *int { return &v }
 
-// The zero-value rule is the one the section would otherwise need a paragraph
-// of documentation to survive: nil takes the default, a number that was
-// written down is spent literally. A `server: 0` that quietly became five
-// seconds would be configuration accepted and not applied.
+// The zero-value rule is the same for all four fields, and it is the one the
+// section would otherwise need a paragraph of documentation to survive: nil
+// takes the default, a number that was written down is spent literally. A
+// `server: 0` that quietly became five seconds would be the same class of
+// failure this whole batch is about - configuration accepted and not applied.
 func TestShutdownBudgetFallbacks(t *testing.T) {
 	for _, tc := range []struct {
 		name string
@@ -54,25 +55,25 @@ func TestShutdownBudgetFallbacks(t *testing.T) {
 			// already had.
 			name: "nothing configured",
 			in:   Shutdown{},
-			want: ShutdownBudget{Server: 5, Cleanup: 3},
+			want: ShutdownBudget{Drain: 0, Server: 5, Cleanup: 3},
 		},
 		{
-			name: "both configured",
-			in:   Shutdown{Server: ptr(8), Cleanup: ptr(4)},
-			want: ShutdownBudget{Server: 8, Cleanup: 4},
+			name: "all three configured",
+			in:   Shutdown{Drain: ptr(10), Server: ptr(8), Cleanup: ptr(4)},
+			want: ShutdownBudget{Drain: 10, Server: 8, Cleanup: 4},
 		},
 		{
 			// The case a plain int could not express: do not wait for
-			// in-flight requests, which is a reasonable thing to ask when the
-			// grace period is very short.
+			// in-flight requests, which is a reasonable thing to ask for when
+			// the grace period is very short.
 			name: "explicit zeros are spent, not replaced",
-			in:   Shutdown{Server: ptr(0), Cleanup: ptr(0)},
-			want: ShutdownBudget{Server: 0, Cleanup: 0},
+			in:   Shutdown{Drain: ptr(0), Server: ptr(0), Cleanup: ptr(0)},
+			want: ShutdownBudget{Drain: 0, Server: 0, Cleanup: 0},
 		},
 		{
 			name: "one field configured, the rest default",
-			in:   Shutdown{Cleanup: ptr(15)},
-			want: ShutdownBudget{Server: 5, Cleanup: 15},
+			in:   Shutdown{Drain: ptr(15)},
+			want: ShutdownBudget{Drain: 15, Server: 5, Cleanup: 3},
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -91,17 +92,18 @@ func TestShutdownBudgetFallbacks(t *testing.T) {
 // failure this section exists to remove - written down, accepted, and not what
 // happens - and there is no reading of a negative wait to honour.
 //
-// The last row is what makes the others mean anything: an implementation that
-// refused every value would pass them all.
+// The last row is what makes the other four mean anything: an implementation
+// that refused every value would pass them all.
 func TestShutdownBudgetRefusesNegativeSeconds(t *testing.T) {
 	for _, tc := range []struct {
 		name    string
 		in      Shutdown
 		wantErr bool
 	}{
+		{name: "negative drain", in: Shutdown{Drain: ptr(-1)}, wantErr: true},
 		{name: "negative server", in: Shutdown{Server: ptr(-1)}, wantErr: true},
 		{name: "negative cleanup", in: Shutdown{Cleanup: ptr(-1)}, wantErr: true},
-		{name: "explicit zeros are not negative", in: Shutdown{Server: ptr(0), Cleanup: ptr(0)}},
+		{name: "explicit zeros are not negative", in: Shutdown{Drain: ptr(0), Server: ptr(0), Cleanup: ptr(0)}},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			_, err := tc.in.Budget()
@@ -118,11 +120,11 @@ func TestShutdownBudgetRefusesNegativeSeconds(t *testing.T) {
 // The message has to name every field that is wrong, not the first one: a
 // caller who fixes one and gets the same error back learns to distrust it.
 func TestShutdownBudgetNamesEveryNegativeField(t *testing.T) {
-	_, err := Shutdown{Server: ptr(-30), Cleanup: ptr(-3)}.Budget()
+	_, err := Shutdown{Drain: ptr(-1), Server: ptr(-30), Cleanup: ptr(-3)}.Budget()
 	if err == nil {
-		t.Fatal("Budget() accepted two negative values")
+		t.Fatal("Budget() accepted three negative values")
 	}
-	for _, name := range []string{"server", "cleanup"} {
+	for _, name := range []string{"drain", "server", "cleanup"} {
 		if !strings.Contains(err.Error(), name) {
 			t.Errorf("%q does not name %s", err, name)
 		}

--- a/config/extend_test.go
+++ b/config/extend_test.go
@@ -58,9 +58,9 @@ func TestShutdownBudgetFallbacks(t *testing.T) {
 			want: ShutdownBudget{Drain: 0, Server: 5, Cleanup: 3},
 		},
 		{
-			name: "all three configured",
-			in:   Shutdown{Drain: ptr(10), Server: ptr(8), Cleanup: ptr(4)},
-			want: ShutdownBudget{Drain: 10, Server: 8, Cleanup: 4},
+			name: "all four configured",
+			in:   Shutdown{Drain: ptr(10), Server: ptr(8), Cleanup: ptr(4), Grace: ptr(30)},
+			want: ShutdownBudget{Drain: 10, Server: 8, Cleanup: 4, Grace: 30},
 		},
 		{
 			// The case a plain int could not express: do not wait for
@@ -103,6 +103,7 @@ func TestShutdownBudgetRefusesNegativeSeconds(t *testing.T) {
 		{name: "negative drain", in: Shutdown{Drain: ptr(-1)}, wantErr: true},
 		{name: "negative server", in: Shutdown{Server: ptr(-1)}, wantErr: true},
 		{name: "negative cleanup", in: Shutdown{Cleanup: ptr(-1)}, wantErr: true},
+		{name: "negative grace", in: Shutdown{Grace: ptr(-1)}, wantErr: true},
 		{name: "explicit zeros are not negative", in: Shutdown{Drain: ptr(0), Server: ptr(0), Cleanup: ptr(0)}},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -120,13 +121,80 @@ func TestShutdownBudgetRefusesNegativeSeconds(t *testing.T) {
 // The message has to name every field that is wrong, not the first one: a
 // caller who fixes one and gets the same error back learns to distrust it.
 func TestShutdownBudgetNamesEveryNegativeField(t *testing.T) {
-	_, err := Shutdown{Drain: ptr(-1), Server: ptr(-30), Cleanup: ptr(-3)}.Budget()
+	_, err := Shutdown{Drain: ptr(-1), Server: ptr(-30), Cleanup: ptr(-3), Grace: ptr(-9)}.Budget()
 	if err == nil {
-		t.Fatal("Budget() accepted three negative values")
+		t.Fatal("Budget() accepted four negative values")
 	}
-	for _, name := range []string{"drain", "server", "cleanup"} {
+	for _, name := range []string{"drain", "server", "cleanup", "grace"} {
 		if !strings.Contains(err.Error(), name) {
 			t.Errorf("%q does not name %s", err, name)
 		}
+	}
+}
+
+// The sum is what has to fit inside the orchestrator's grace period, and the
+// verdict is only reached when a grace period was configured. A fixed
+// threshold instead would warn about the manifest this repository ships.
+func TestShutdownBudgetOverrun(t *testing.T) {
+	resolved := func(s Shutdown) ShutdownBudget {
+		b, err := s.Budget()
+		if err != nil {
+			t.Fatalf("Budget() = %v", err)
+		}
+		return b
+	}
+	for _, tc := range []struct {
+		name        string
+		budget      ShutdownBudget
+		wantTotal   int
+		wantOverrun int
+	}{
+		{
+			name:      "defaults, no grace period to judge against",
+			budget:    resolved(Shutdown{}),
+			wantTotal: 8,
+		},
+		{
+			name:      "fits with room to spare",
+			budget:    resolved(Shutdown{Drain: ptr(10), Grace: ptr(30)}),
+			wantTotal: 18,
+		},
+		{
+			// Equal is not a fit. The grace period is when SIGKILL is sent, so
+			// a budget that ends exactly then leaves the last callback no time
+			// to return.
+			name:        "exactly equal still overruns",
+			budget:      resolved(Shutdown{Drain: ptr(22), Grace: ptr(30)}),
+			wantTotal:   30,
+			wantOverrun: 1,
+		},
+		{
+			name:        "over by five",
+			budget:      resolved(Shutdown{Drain: ptr(26), Grace: ptr(30)}),
+			wantTotal:   34,
+			wantOverrun: 5,
+		},
+		{
+			// The reason the threshold is a configured value rather than a
+			// constant: the same budget is wrong under `docker stop` and right
+			// under a Kubernetes default.
+			name:        "the docker default is the tighter one",
+			budget:      resolved(Shutdown{Drain: ptr(10), Grace: ptr(10)}),
+			wantTotal:   18,
+			wantOverrun: 9,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.budget.Total(); got != tc.wantTotal {
+				t.Errorf("Total() = %d, want %d", got, tc.wantTotal)
+			}
+			if got := tc.budget.Overrun(); got != tc.wantOverrun {
+				t.Errorf("Overrun() = %d, want %d", got, tc.wantOverrun)
+			}
+			if over := tc.budget.Overrun(); over > 0 && tc.budget.Total()-over >= tc.budget.Grace {
+				t.Errorf("Overrun() = %d does not bring %d under the %d grace period",
+					over, tc.budget.Total(), tc.budget.Grace)
+			}
+		})
 	}
 }

--- a/config/settings.full.yml
+++ b/config/settings.full.yml
@@ -108,6 +108,14 @@ settings:
       server: 5
       # How long the BeforeExit cleanup callbacks get after that.
       cleanup: 3
+      # The stop grace period the orchestrator gives this process - `docker stop
+      # --timeout`, or terminationGracePeriodSeconds. Nothing reads it during a
+      # shutdown; start-up uses it to say whether the three budgets above fit
+      # inside it, and warns when they do not. Left out, nothing is compared:
+      # the reference values are 10s for docker and 30s for Kubernetes, three
+      # times apart, and a fixed threshold would warn about correct
+      # configurations.
+      #grace: 30
     # fileStore 对象存储。上传接口的 source 参数决定走哪一家：
     #   source=1 只存本地，source=2 阿里云 OSS，source=3 七牛 Kodo
     # 没有填的那一家在被请求时会返回明确错误，不会静默存到别处。

--- a/config/settings.full.yml
+++ b/config/settings.full.yml
@@ -82,11 +82,28 @@ settings:
     # 会被负载均衡、监控和压测统计成成功）。
     rateLimit:
       inboundQPS: 200
-    # shutdown budgets, in seconds. The two are spent one after the other, and
-    # their sum has to stay inside the stop grace period the orchestrator
+    # shutdown budgets, in seconds. The three are spent one after the other,
+    # and their sum has to stay inside the stop grace period the orchestrator
     # allows - once it is up, SIGKILL arrives part-way through the cleanup
-    # callbacks, which is worse than not waiting at all.
+    # callbacks, which is worse than not draining at all.
     shutdown:
+      # How long to keep serving normally after a stop signal arrives. For that
+      # long /ready answers 503 and keep-alive is switched off, which is what
+      # gives a load balancer time to take this instance out of rotation before
+      # the listener closes.
+      #
+      # What to set depends on who removes this instance and on what basis. A
+      # load balancer that polls /ready itself needs at least "check interval x
+      # failure threshold + however long removal takes to apply". A Kubernetes
+      # Service removes the endpoint when the Pod is deleted, concurrently with
+      # SIGTERM and regardless of what the probe returns, so here this covers
+      # the delay in that removal reaching every node.
+      #
+      # 0 by default: a deployment that leaves this alone shuts down exactly as
+      # it did before this section existed. It also means /ready never reports
+      # draining - the flip and the closed listener are microseconds apart, and
+      # no poller reads anything in between.
+      drain: 0
       # How long to wait for in-flight requests once the listener is closed.
       server: 5
       # How long the BeforeExit cleanup callbacks get after that.

--- a/config/settings.full.yml
+++ b/config/settings.full.yml
@@ -82,6 +82,15 @@ settings:
     # 会被负载均衡、监控和压测统计成成功）。
     rateLimit:
       inboundQPS: 200
+    # shutdown budgets, in seconds. The two are spent one after the other, and
+    # their sum has to stay inside the stop grace period the orchestrator
+    # allows - once it is up, SIGKILL arrives part-way through the cleanup
+    # callbacks, which is worse than not waiting at all.
+    shutdown:
+      # How long to wait for in-flight requests once the listener is closed.
+      server: 5
+      # How long the BeforeExit cleanup callbacks get after that.
+      cleanup: 3
     # fileStore 对象存储。上传接口的 source 参数决定走哪一家：
     #   source=1 只存本地，source=2 阿里云 OSS，source=3 七牛 Kodo
     # 没有填的那一家在被请求时会返回明确错误，不会静默存到别处。

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -92,6 +92,14 @@ settings:
       server: 5
       # How long the BeforeExit cleanup callbacks get after that.
       cleanup: 3
+      # The stop grace period the orchestrator gives this process - `docker stop
+      # --timeout`, or terminationGracePeriodSeconds. Nothing reads it during a
+      # shutdown; start-up uses it to say whether the three budgets above fit
+      # inside it, and warns when they do not. Left out, nothing is compared:
+      # the reference values are 10s for docker and 30s for Kubernetes, three
+      # times apart, and a fixed threshold would warn about correct
+      # configurations.
+      #grace: 30
   cache:
 #    redis:
 #      addr: 127.0.0.1:6379

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -66,6 +66,15 @@ settings:
     # 会被负载均衡、监控和压测统计成成功）。
     rateLimit:
       inboundQPS: 200
+    # shutdown budgets, in seconds. The two are spent one after the other, and
+    # their sum has to stay inside the stop grace period the orchestrator
+    # allows - once it is up, SIGKILL arrives part-way through the cleanup
+    # callbacks, which is worse than not waiting at all.
+    shutdown:
+      # How long to wait for in-flight requests once the listener is closed.
+      server: 5
+      # How long the BeforeExit cleanup callbacks get after that.
+      cleanup: 3
   cache:
 #    redis:
 #      addr: 127.0.0.1:6379

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -66,11 +66,28 @@ settings:
     # 会被负载均衡、监控和压测统计成成功）。
     rateLimit:
       inboundQPS: 200
-    # shutdown budgets, in seconds. The two are spent one after the other, and
-    # their sum has to stay inside the stop grace period the orchestrator
+    # shutdown budgets, in seconds. The three are spent one after the other,
+    # and their sum has to stay inside the stop grace period the orchestrator
     # allows - once it is up, SIGKILL arrives part-way through the cleanup
-    # callbacks, which is worse than not waiting at all.
+    # callbacks, which is worse than not draining at all.
     shutdown:
+      # How long to keep serving normally after a stop signal arrives. For that
+      # long /ready answers 503 and keep-alive is switched off, which is what
+      # gives a load balancer time to take this instance out of rotation before
+      # the listener closes.
+      #
+      # What to set depends on who removes this instance and on what basis. A
+      # load balancer that polls /ready itself needs at least "check interval x
+      # failure threshold + however long removal takes to apply". A Kubernetes
+      # Service removes the endpoint when the Pod is deleted, concurrently with
+      # SIGTERM and regardless of what the probe returns, so here this covers
+      # the delay in that removal reaching every node.
+      #
+      # 0 by default: a deployment that leaves this alone shuts down exactly as
+      # it did before this section existed. It also means /ready never reports
+      # draining - the flip and the closed listener are microseconds apart, and
+      # no poller reads anything in between.
+      drain: 0
       # How long to wait for in-flight requests once the listener is closed.
       server: 5
       # How long the BeforeExit cleanup callbacks get after that.

--- a/config/settings_shutdown_test.go
+++ b/config/settings_shutdown_test.go
@@ -22,7 +22,7 @@ func (*shippedSettings) OnChange() {}
 // The shutdown section has to arrive where it is read from, and with the
 // values the documentation claims.
 //
-// This is the failure this section exists to remove, one level up: the loader
+// This is the failure this batch exists to remove, one level up: the loader
 // discards keys no field matches, without an error and without a log line, so
 // a section put in the wrong place is written, accepted, and never applied.
 // Nothing but loading the shipped file through the real loader can tell the
@@ -46,12 +46,13 @@ func TestTheShippedSettingsReachTheShutdownStruct(t *testing.T) {
 			t.Cleanup(func() { _ = c.Close() })
 
 			s := loaded.Settings.Extend.Shutdown
-			if s.Server == nil || s.Cleanup == nil {
+			if s.Drain == nil || s.Server == nil || s.Cleanup == nil {
 				t.Fatalf("%s left extend.shutdown unfilled (%+v); the section is written but nothing reads it",
 					name, s)
 			}
 
 			want := ShutdownBudget{
+				Drain:   DefaultDrainSeconds,
 				Server:  DefaultServerSeconds,
 				Cleanup: DefaultCleanupSeconds,
 			}

--- a/config/settings_shutdown_test.go
+++ b/config/settings_shutdown_test.go
@@ -1,0 +1,67 @@
+package config
+
+import (
+	"testing"
+
+	coreconfig "github.com/go-admin-team/go-admin-core/v2/config"
+	"github.com/go-admin-team/go-admin-core/v2/config/source/file"
+)
+
+// shippedSettings is the shape the loader fills in, cut down to the part under
+// test. The reader is JSON-based, so the keys are matched against field names
+// case-insensitively - which is exactly the matching that silently drops a
+// section the struct has no field for.
+type shippedSettings struct {
+	Settings struct {
+		Extend Extend
+	}
+}
+
+func (*shippedSettings) OnChange() {}
+
+// The shutdown section has to arrive where it is read from, and with the
+// values the documentation claims.
+//
+// This is the failure this section exists to remove, one level up: the loader
+// discards keys no field matches, without an error and without a log line, so
+// a section put in the wrong place is written, accepted, and never applied.
+// Nothing but loading the shipped file through the real loader can tell the
+// two apart - the struct compiles either way.
+//
+// The values are asserted as well as the arrival. A settings.yml that shipped
+// a different default from config.Default*Seconds would give two answers to
+// "what does an unconfigured deployment spend", and the file is the one people
+// read.
+func TestTheShippedSettingsReachTheShutdownStruct(t *testing.T) {
+	for _, name := range []string{"settings.yml", "settings.full.yml"} {
+		t.Run(name, func(t *testing.T) {
+			var loaded shippedSettings
+			c, err := coreconfig.NewConfig(
+				coreconfig.WithSource(file.NewSource(file.WithPath(name))),
+				coreconfig.WithEntity(&loaded),
+			)
+			if err != nil {
+				t.Fatalf("load %s: %v", name, err)
+			}
+			t.Cleanup(func() { _ = c.Close() })
+
+			s := loaded.Settings.Extend.Shutdown
+			if s.Server == nil || s.Cleanup == nil {
+				t.Fatalf("%s left extend.shutdown unfilled (%+v); the section is written but nothing reads it",
+					name, s)
+			}
+
+			want := ShutdownBudget{
+				Server:  DefaultServerSeconds,
+				Cleanup: DefaultCleanupSeconds,
+			}
+			got, err := s.Budget()
+			if err != nil {
+				t.Fatalf("%s does not resolve: %v", name, err)
+			}
+			if got != want {
+				t.Errorf("%s ships %+v, want the documented defaults %+v", name, got, want)
+			}
+		})
+	}
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,13 @@ services:
     restart: always
     ports:
       - 8000:8000
+    # Compose allows 10 seconds by default, and this process spends
+    # drain + server + cleanup from extend.shutdown before it exits - 8 out of
+    # the box, more for anyone who configures a drain window. Past the deadline
+    # it is sent SIGKILL and the cleanup callbacks are cut off part-way
+    # through. checksilent's docker-stop-cuts-shutdown-short check compares
+    # this against config/settings.yml.
+    stop_grace_period: 30s
     volumes:
       - ./config/:/go-admin-api/config/
       - ./static/:/go-admin-api/static/

--- a/docs/contract.md
+++ b/docs/contract.md
@@ -803,5 +803,6 @@ core 里那行注释自己写着「The interface has no way to report this to th
 `checksilent` 一个文件都看不到。所以它保的是**这个仓库和它的 fork**，
 不是你的应用——你的应用要自己跑自己的检查。
 
-`checksilent` 还检查另外五类"不出声的失败"，写模块时值得先看一眼
-`go run ./tools/checksilent -h`。
+`checksilent` 还检查其他几类"不出声的失败"，写模块时值得先看一眼
+`AGENTS.md` 的「静默失败校验」一节，或者 `tools/checksilent/checks.go` 里的
+`runChecks`（`-h` 只打印命令行参数，不列检查）。

--- a/go.mod
+++ b/go.mod
@@ -26,6 +26,7 @@ require (
 	github.com/swaggo/gin-swagger v1.6.1
 	github.com/swaggo/swag v1.16.6
 	github.com/unrolled/secure v1.17.0
+	go.yaml.in/yaml/v3 v3.0.5
 	golang.org/x/crypto v0.54.0
 	gorm.io/driver/mysql v1.6.0
 	gorm.io/driver/postgres v1.6.2
@@ -126,7 +127,6 @@ require (
 	go.uber.org/atomic v1.11.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.27.1 // indirect
-	go.yaml.in/yaml/v3 v3.0.5 // indirect
 	golang.org/x/arch v0.30.0 // indirect
 	golang.org/x/exp v0.0.0-20251219203646-944ab1f22d93 // indirect
 	golang.org/x/image v0.41.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -145,10 +145,6 @@ github.com/glebarez/go-sqlite v1.22.0 h1:uAcMJhaA6r3LHMTFgP0SifzgXg46yJkgxqyuyec
 github.com/glebarez/go-sqlite v1.22.0/go.mod h1:PlBIdHe0+aUEFn+r2/uthrWq4FxbzugL0L8Li6yQJbc=
 github.com/glebarez/sqlite v1.11.0 h1:wSG0irqzP6VurnMEpFGer5Li19RpIRi2qvQz++w0GMw=
 github.com/glebarez/sqlite v1.11.0/go.mod h1:h8/o8j5wiAsqSPoWELDUdJXhjAhsVliSn7bWZjOhrgQ=
-github.com/go-admin-team/go-admin-core/v2 v2.5.0 h1:aD1SALklBxizGB9u8cOgm4OT8z656FM83F4fD6dMz9g=
-github.com/go-admin-team/go-admin-core/v2 v2.5.0/go.mod h1:LG/XvEfOplbuadKrPTPm0Nu5pN06aQUNZZC3ao4B4gs=
-github.com/go-admin-team/go-admin-core/v2 v2.6.0 h1:sRoZaxniTpbe287uR/uWpA14Jl1GTAcfGXLKoBLph2w=
-github.com/go-admin-team/go-admin-core/v2 v2.6.0/go.mod h1:LG/XvEfOplbuadKrPTPm0Nu5pN06aQUNZZC3ao4B4gs=
 github.com/go-admin-team/go-admin-core/v2 v2.7.0 h1:1qV0/5iFBvkE3BRtm4ip0v0QYG9Fgx4UtOTd8zkQT9c=
 github.com/go-admin-team/go-admin-core/v2 v2.7.0/go.mod h1:LG/XvEfOplbuadKrPTPm0Nu5pN06aQUNZZC3ao4B4gs=
 github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=

--- a/scripts/k8s/deploy.yml
+++ b/scripts/k8s/deploy.yml
@@ -22,6 +22,11 @@ metadata:
     app: go-admin
     version: v1
 spec:
+  # One replica, and the drain window below buys nothing at one replica: there
+  # is nowhere to send the traffic this pod stops taking. Raising it needs one
+  # more change than the number - the volume below is shared by every replica,
+  # and the log path in settings.yml lives on it, so a second pod would append
+  # to the same rotating file.
   replicas: 1
   selector:
     matchLabels:
@@ -39,6 +44,40 @@ spec:
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 8000
+        # Readiness answers "send me requests". It fails while the database or
+        # the cache is unreachable, so this pod stays out of the Service until
+        # the datastore settings.yml names is really there - which is a change
+        # from having no probe at all, where a pod with an unreachable database
+        # was still sent traffic.
+        #
+        # timeoutSeconds is 3 rather than the default 1 because the handler
+        # allows its checks 2 seconds (readyTimeout in
+        # app/other/router/monitor.go). At the default, a database that answers
+        # in 1.2s is recorded as a failed check while the handler is returning
+        # 200.
+        readinessProbe:
+          httpGet:
+            path: /api/v1/ready
+            port: 8000
+          periodSeconds: 5
+          timeoutSeconds: 3
+          failureThreshold: 3
+        # Liveness answers "restart me", which is a different question: a
+        # process whose database is unreachable does not want restarting, so
+        # this points at /health, which is a bare 200. Both probes skip the
+        # rate limiter - see exemptProbes in cmd/api/server.go - because a
+        # liveness probe that collects 429s under load gets the container
+        # restarted at the moment the deployment can least afford to lose it.
+        #
+        # initialDelaySeconds covers the migrations, which run before the
+        # listener opens.
+        livenessProbe:
+          httpGet:
+            path: /api/v1/health
+            port: 8000
+          initialDelaySeconds: 15
+          periodSeconds: 10
+          failureThreshold: 3
         volumeMounts:
         - name: go-admin
           mountPath: /temp
@@ -47,6 +86,18 @@ spec:
         - name: go-admin-config
           mountPath: /config/
           readOnly: true
+      # SIGKILL arrives when this is up, so it has to be longer than what the
+      # process spends shutting down: extend.shutdown's drain + server +
+      # cleanup, which settings.yml ships as 0 + 5 + 3. Raise drain here and
+      # this number has to follow, or the cleanup callbacks are cut off
+      # part-way through - checksilent's shutdown-budget-overruns-grace check
+      # is what notices.
+      #
+      # No preStop hook on purpose. A sleep there would be spent before the
+      # process is told anything, so BeginDraining never runs and /ready
+      # answers 200 for the whole of it - and it would be added to the budget
+      # above rather than replacing any of it.
+      terminationGracePeriodSeconds: 30
       volumes:
       - name: go-admin
         persistentVolumeClaim:

--- a/tools/checksilent/checks.go
+++ b/tools/checksilent/checks.go
@@ -21,6 +21,8 @@ const (
 	checkImportBoundary = "contract-import-boundary"
 	checkShimAlias      = "contract-shim-alias"
 	checkDataScopeRoute = "datascope-route-unguarded"
+	checkShutdownGrace  = "shutdown-budget-overruns-grace"
+	checkDockerStop     = "docker-stop-cuts-shutdown-short"
 )
 
 // Package paths, relative to the module. Spelled once so a module rename
@@ -49,6 +51,17 @@ func runChecks(s *snapshot, opt options) ([]Finding, error) {
 	out = append(out, checkContractImportBoundary(s)...)
 	out = append(out, checkContractShimAlias(s)...)
 	out = append(out, checkDataScopeRoutes(s)...)
+
+	for _, run := range []func(*snapshot) ([]Finding, error){
+		checkShutdownBudgetFitsGrace,
+		checkDockerStopGrace,
+	} {
+		fs, err := run(s)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, fs...)
+	}
 
 	if opt.UIDir != "" {
 		fs, err := checkMenuNames(s, opt.UIDir)

--- a/tools/checksilent/main.go
+++ b/tools/checksilent/main.go
@@ -1,13 +1,23 @@
 // Command checksilent reports the failures in this repository that do not
 // announce themselves: no error, no log line, behaviour quietly wrong.
 //
-// Seven checks, six of them ERROR and one WARN. An ERROR fails the run; a WARN
-// prints and does not. The split is not about how bad the consequence is - all
-// seven are bad - but about how certain the detection is. Everything reported as
-// an ERROR is decided from this repository's own syntax. The one WARN compares
-// against a second repository through a regular expression, and a check that
-// can be wrong must not be able to stop a build, or the first response to it
-// will be an ignore comment.
+// An ERROR fails the run; a WARN prints and does not. The split is not about
+// how bad the consequence is - every one of these is bad - but about how much
+// room is left to act.
+//
+// Most of them report only ERROR: each is decided from this repository's own
+// files and is either true or not. The menu-name check reports only WARN,
+// because it compares against a second repository through a regular
+// expression, and a check that can be wrong must not be able to stop a build
+// or the first response to it will be an ignore comment. The two
+// shutdown-budget checks report at both levels from one arithmetic: a budget
+// that already overruns is an ERROR, and one that fits with no headroom left
+// is a WARN - it works today, so failing the build on it would be failing a
+// correct configuration.
+//
+// The list of checks is runChecks in checks.go. It is deliberately not
+// repeated here as a count: the two places that carried one were both wrong by
+// the time anybody looked.
 //
 // Usage:
 //

--- a/tools/checksilent/shutdownbudget.go
+++ b/tools/checksilent/shutdownbudget.go
@@ -1,0 +1,651 @@
+package main
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+
+	yaml "go.yaml.in/yaml/v3"
+)
+
+// The files this check compares, and the package the fallbacks come from.
+const (
+	settingsFile     = "config/settings.yml"
+	k8sDeployFile    = "scripts/k8s/deploy.yml"
+	pkgHostConfig    = "config"
+	drainConstName   = "DefaultDrainSeconds"
+	serverConstName  = "DefaultServerSeconds"
+	cleanupConstName = "DefaultCleanupSeconds"
+)
+
+// graceMarginSeconds is the headroom a shutdown budget needs beyond itself.
+//
+// Spelled once and used by both checks below, because they fail the same way:
+// somebody raises a budget in config/settings.yml and does not go looking for
+// the two other places that have to allow room for it. Two margins would
+// eventually be two different numbers.
+const graceMarginSeconds = 5
+
+// checkShutdownBudgetFitsGrace compares the shutdown budget this repository
+// ships against the stop grace period its own Kubernetes manifest allows.
+//
+// The two are not merely adjacent examples. scripts/k8s/prerun.sh builds the
+// settings-admin ConfigMap out of config/settings.yml, and the Deployment
+// mounts that ConfigMap - so the manifest deploys that file.
+//
+// The budgets are spent one after the other, and when their sum reaches
+// terminationGracePeriodSeconds the kubelet sends SIGKILL while the cleanup
+// callbacks are still running. Nothing reports it: the pod disappears
+// mid-shutdown and it reads as a crash rather than as a number that was raised
+// in one file and not the other. Which is how it would be raised - drain is
+// the interesting knob and the grace period is in a different directory.
+//
+// Two levels, and an overrun is not also reported as a shortage of headroom:
+// every Error satisfies the Warn condition too, and an Error that always drags
+// a duplicate Warn behind it teaches people to skip Warns.
+//
+// A preStop hook counts, even though the shipped manifest has none. It is
+// spent before the process is told anything, so it is added to the budget
+// rather than overlapping it - and a self-check that cannot see it would
+// understate the real cost by however long somebody set it to, which is worse
+// than not checking.
+//
+// It reports nothing when either file is absent and when the manifest sets no
+// grace period, because there is then no second number to disagree with.
+func checkShutdownBudgetFitsGrace(s *snapshot) ([]Finding, error) {
+	budget, ok, err := shippedShutdownBudget(s)
+	if err != nil || !ok {
+		return nil, err
+	}
+	m, ok, err := readManifest(s)
+	if err != nil || !ok {
+		return nil, err
+	}
+	if m.grace == nil {
+		return nil, nil
+	}
+
+	var out []Finding
+	if m.preStopUnreadable {
+		out = append(out, Finding{
+			Check:    checkShutdownGrace,
+			Severity: Warn.String(),
+			File:     k8sDeployFile,
+			Line:     m.preStopLine,
+			Col:      1,
+			Message: "this preStop hook is not a sleep, so how long it takes cannot be read here " +
+				"and is not in the sum below; it is spent before the process is told anything, " +
+				"so whatever it costs has to fit inside terminationGracePeriodSeconds as well.",
+			severity: Warn,
+		})
+	}
+
+	total := m.preStop + budget.drain + budget.server + budget.cleanup
+	grace := *m.grace
+	spelled := fmt.Sprintf("preStop %d + drain %d + server %d + cleanup %d",
+		m.preStop, budget.drain, budget.server, budget.cleanup)
+
+	switch {
+	case total >= grace:
+		out = append(out, Finding{
+			Check:    checkShutdownGrace,
+			Severity: Error.String(),
+			File:     k8sDeployFile,
+			Line:     m.graceLine,
+			Col:      1,
+			Message: fmt.Sprintf(
+				"terminationGracePeriodSeconds is %d and the shutdown takes %d (%s, from %s); "+
+					"SIGKILL would arrive while the cleanup callbacks are still running. "+
+					"Raise it to %d, or take %d off the budget.",
+				grace, total, spelled, settingsFile,
+				total+graceMarginSeconds, total+graceMarginSeconds-grace),
+			severity: Error,
+		})
+	case total+graceMarginSeconds > grace:
+		out = append(out, Finding{
+			Check:    checkShutdownGrace,
+			Severity: Warn.String(),
+			File:     k8sDeployFile,
+			Line:     m.graceLine,
+			Col:      1,
+			Message: fmt.Sprintf(
+				"terminationGracePeriodSeconds is %d and the shutdown takes %d (%s, from %s), "+
+					"which leaves under %ds of headroom; a callback that runs slightly long is "+
+					"cut off. Raise it to %d.",
+				grace, total, spelled, settingsFile, graceMarginSeconds, total+graceMarginSeconds),
+			severity: Warn,
+		})
+	}
+	return out, nil
+}
+
+// dockerStopArgs matches a stop command in a script or a workflow.
+var (
+	dockerStopArgs = regexp.MustCompile(`\bdocker\s+stop\b`)
+	// --timeout is the current name, --time its deprecated spelling and -t the
+	// short form; docker still accepts all three, so all three are read. The
+	// long name comes first because --time is a prefix of it, and a flag that
+	// the check cannot read is reported as no deadline at all - which would
+	// have this tool pressing people towards the deprecated spelling.
+	dockerStopTime = regexp.MustCompile(`(--timeout|--time|-t)[=\s]*(\d+)`)
+)
+
+// checkDockerStopGrace reports a stop path that does not allow this process
+// the time it spends shutting down.
+//
+// docker allows ten seconds unless told otherwise, and that number is nowhere
+// near the command - so a budget raised in config/settings.yml passes every
+// test, deploys, and then has its cleanup callbacks killed on the next
+// release. Same failure as the manifest's grace period, same arithmetic, same
+// margin; only the file it lives in is different.
+//
+// Both ways of stopping this repository's container are covered, because
+// covering one of two identical paths is what produces a clean run that means
+// nothing: `docker stop` in a workflow or a script, and stop_grace_period in
+// the compose file the Makefile's own `make run` uses.
+//
+// An absent deadline is reported rather than assumed to be ten: the value that
+// applies is then invisible at the call site and cannot follow the budget.
+func checkDockerStopGrace(s *snapshot) ([]Finding, error) {
+	budget, ok, err := shippedShutdownBudget(s)
+	if err != nil || !ok {
+		return nil, err
+	}
+	total := budget.drain + budget.server + budget.cleanup
+	spelled := fmt.Sprintf("drain %d + server %d + cleanup %d",
+		budget.drain, budget.server, budget.cleanup)
+
+	sites, err := findStopDeadlines(s)
+	if err != nil {
+		return nil, err
+	}
+
+	var out []Finding
+	for _, site := range sites {
+		finding := Finding{
+			Check: checkDockerStop,
+			File:  site.file,
+			Line:  site.line,
+			Col:   1,
+		}
+		switch {
+		case !site.set:
+			finding.Severity, finding.severity = Error.String(), Error
+			finding.Message = fmt.Sprintf(
+				"%s allows the default %d seconds, and this process spends %d shutting down "+
+					"(%s, from %s). %s.",
+				site.what, dockerDefaultGraceSeconds, total, spelled, settingsFile,
+				site.fix(total+graceMarginSeconds))
+		case site.seconds <= total:
+			finding.Severity, finding.severity = Error.String(), Error
+			finding.Message = fmt.Sprintf(
+				"%s allows %d seconds and this shutdown takes %d (%s, from %s); the cleanup "+
+					"callbacks are killed part-way through. %s.",
+				site.what, site.seconds, total, spelled, settingsFile,
+				site.fix(total+graceMarginSeconds))
+		case site.seconds < total+graceMarginSeconds:
+			finding.Severity, finding.severity = Warn.String(), Warn
+			finding.Message = fmt.Sprintf(
+				"%s allows %d seconds over a shutdown that takes %d (%s, from %s), which leaves "+
+					"under %ds of headroom. %s.",
+				site.what, site.seconds, total, spelled, settingsFile, graceMarginSeconds,
+				site.fix(total+graceMarginSeconds))
+		default:
+			continue
+		}
+		out = append(out, finding)
+	}
+	return out, nil
+}
+
+// dockerDefaultGraceSeconds is what docker allows a container to stop in when
+// nothing says otherwise. It applies to `docker stop` and to compose alike.
+const dockerDefaultGraceSeconds = 10
+
+// stopSite is one place this repository decides how long a container gets.
+type stopSite struct {
+	file string
+	line int
+	// what names the setting in the finding, in the spelling of the file it
+	// was found in.
+	what string
+	// compose says which of the two fixes to suggest.
+	compose bool
+	seconds int
+	set     bool
+}
+
+func (s stopSite) fix(seconds int) string {
+	if s.compose {
+		return fmt.Sprintf("Set stop_grace_period: %ds", seconds)
+	}
+	return fmt.Sprintf("Pass --timeout %d", seconds)
+}
+
+func findStopDeadlines(s *snapshot) ([]stopSite, error) {
+	sites, err := findDockerStops(s.Root)
+	if err != nil {
+		return nil, err
+	}
+	compose, err := findComposeServices(s)
+	if err != nil {
+		return nil, err
+	}
+	return append(sites, compose...), nil
+}
+
+// dockerStopExtensions and dockerStopNames are where a stop command can be
+// written in this repository: workflows, shell scripts and the Makefile.
+var (
+	dockerStopExtensions = map[string]bool{".yml": true, ".yaml": true, ".sh": true, ".bash": true}
+	dockerStopNames      = map[string]bool{"Makefile": true, "makefile": true}
+)
+
+func findDockerStops(root string) ([]stopSite, error) {
+	var out []stopSite
+	err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.IsDir() {
+			if path != root && skippedDirs[info.Name()] {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !dockerStopExtensions[filepath.Ext(path)] && !dockerStopNames[info.Name()] {
+			return nil
+		}
+		b, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		rel, err := filepath.Rel(root, path)
+		if err != nil {
+			return err
+		}
+		for i, line := range strings.Split(string(b), "\n") {
+			// A commented-out command is not one that runs, and the settings
+			// file describes `docker stop` in prose right beside the budget
+			// this check reads.
+			if trimmed := strings.TrimSpace(line); strings.HasPrefix(trimmed, "#") {
+				continue
+			}
+			if !dockerStopArgs.MatchString(line) {
+				continue
+			}
+			site := stopSite{
+				file: filepath.ToSlash(rel),
+				line: i + 1,
+				what: "`docker stop` with no --timeout",
+			}
+			if m := dockerStopTime.FindStringSubmatch(line); m != nil {
+				seconds, err := strconv.Atoi(m[2])
+				if err != nil {
+					continue
+				}
+				// Quoted back in the spelling it was written in, so the
+				// message cannot misreport what the line says.
+				site.what = fmt.Sprintf("`docker stop %s %d`", m[1], seconds)
+				site.seconds, site.set = seconds, true
+			}
+			out = append(out, site)
+		}
+		return nil
+	})
+	return out, err
+}
+
+type shutdownSeconds struct{ drain, server, cleanup int }
+
+// shippedShutdownBudget reads extend.shutdown out of the settings file this
+// repository ships, filling in whatever it leaves out from the Go constants
+// that do the same at run time.
+//
+// Taking the fallbacks from the snapshot rather than repeating 0/5/3 here is
+// what keeps this honest when the defaults move: a tool that carries its own
+// copy of the number it is checking eventually checks the wrong one.
+//
+// A negative value is left alone. config.Shutdown.Budget refuses it and the
+// server does not start, so it is not a failure that passes unnoticed - and
+// adding a negative into the sums above would understate them.
+func shippedShutdownBudget(s *snapshot) (shutdownSeconds, bool, error) {
+	raw, ok, err := readRepoFile(s, settingsFile)
+	if err != nil || !ok {
+		return shutdownSeconds{}, false, err
+	}
+
+	var doc struct {
+		Settings struct {
+			Extend struct {
+				Shutdown *struct {
+					Drain   *int `yaml:"drain"`
+					Server  *int `yaml:"server"`
+					Cleanup *int `yaml:"cleanup"`
+				} `yaml:"shutdown"`
+			} `yaml:"extend"`
+		} `yaml:"settings"`
+	}
+	if err := yaml.Unmarshal(raw, &doc); err != nil {
+		return shutdownSeconds{}, false, fmt.Errorf("%s: %w", settingsFile, err)
+	}
+	section := doc.Settings.Extend.Shutdown
+	if section == nil {
+		return shutdownSeconds{}, false, nil
+	}
+
+	defaults, ok := s.hostConfigDefaults()
+	if !ok {
+		// The constants moved or were renamed. Reporting nothing would let the
+		// check go quiet, which is the failure it exists to catch, so this
+		// stops the run instead.
+		return shutdownSeconds{}, false, fmt.Errorf(
+			"%s has extend.shutdown but package %s declares no %s/%s/%s to fall back on",
+			settingsFile, pkgHostConfig, drainConstName, serverConstName, cleanupConstName)
+	}
+
+	budget := shutdownSeconds{
+		drain:   orDefault(section.Drain, defaults.drain),
+		server:  orDefault(section.Server, defaults.server),
+		cleanup: orDefault(section.Cleanup, defaults.cleanup),
+	}
+	if budget.drain < 0 || budget.server < 0 || budget.cleanup < 0 {
+		return shutdownSeconds{}, false, nil
+	}
+	return budget, true, nil
+}
+
+func orDefault(configured *int, fallback int) int {
+	if configured != nil {
+		return *configured
+	}
+	return fallback
+}
+
+// hostConfigDefaults reads the three fallback constants out of the parsed tree.
+func (s *snapshot) hostConfigDefaults() (shutdownSeconds, bool) {
+	for _, sf := range s.Files {
+		if sf.Pkg != s.pkg(pkgHostConfig) {
+			continue
+		}
+		drain, okDrain := sf.consts[drainConstName]
+		server, okServer := sf.consts[serverConstName]
+		cleanup, okCleanup := sf.consts[cleanupConstName]
+		if okDrain && okServer && okCleanup {
+			return shutdownSeconds{int(drain), int(server), int(cleanup)}, true
+		}
+	}
+	return shutdownSeconds{}, false
+}
+
+// manifest is what the shipped Deployment says about how long it will wait.
+type manifest struct {
+	grace     *int
+	graceLine int
+	// preStop is the longest sleep any container's hook performs, since the
+	// hooks of several containers run at the same time.
+	preStop     int
+	preStopLine int
+
+	preStopUnreadable bool
+}
+
+var preStopSleep = regexp.MustCompile(`\bsleep\s+(\d+)s?\b`)
+
+// readManifest finds the grace period and the preStop hooks in the shipped
+// manifest, with the lines they are on so a finding can be opened at them.
+//
+// The file holds several documents and only the Deployment carries a pod
+// template, so every document is decoded and the first one with a grace period
+// wins.
+func readManifest(s *snapshot) (manifest, bool, error) {
+	raw, ok, err := readRepoFile(s, k8sDeployFile)
+	if err != nil || !ok {
+		return manifest{}, false, err
+	}
+
+	dec := yaml.NewDecoder(bytes.NewReader(raw))
+	for {
+		var doc struct {
+			Spec struct {
+				Template struct {
+					Spec struct {
+						Grace      *int `yaml:"terminationGracePeriodSeconds"`
+						Containers []struct {
+							Lifecycle struct {
+								// A value, not a pointer: yaml.v3 only hands
+								// the raw node to a field of type yaml.Node,
+								// and a *yaml.Node field is allocated and left
+								// empty - which reads as "the hook is there but
+								// unreadable" for every manifest that has one.
+								PreStop yaml.Node `yaml:"preStop"`
+							} `yaml:"lifecycle"`
+						} `yaml:"containers"`
+					} `yaml:"spec"`
+				} `yaml:"template"`
+			} `yaml:"spec"`
+		}
+		switch err := dec.Decode(&doc); {
+		case errors.Is(err, io.EOF):
+			return manifest{}, false, nil
+		case err != nil:
+			return manifest{}, false, fmt.Errorf("%s: %w", k8sDeployFile, err)
+		}
+
+		pod := doc.Spec.Template.Spec
+		if pod.Grace == nil && len(pod.Containers) == 0 {
+			continue
+		}
+
+		m := manifest{
+			grace:     pod.Grace,
+			graceLine: lineOf(raw, "terminationGracePeriodSeconds:"),
+		}
+		for _, c := range pod.Containers {
+			hook := c.Lifecycle.PreStop
+			if hook.Kind == 0 {
+				continue
+			}
+			m.preStopLine = hook.Line
+			if seconds, ok := preStopSeconds(&hook); ok {
+				// The longest one, not the sum: the hooks of several
+				// containers run at the same time.
+				if seconds > m.preStop {
+					m.preStop = seconds
+				}
+				continue
+			}
+			m.preStopUnreadable = true
+		}
+		if m.grace == nil {
+			continue
+		}
+		return m, true, nil
+	}
+}
+
+// preStopSeconds reads how long a hook sleeps for.
+//
+// Every scalar under the hook is joined and searched, because the sleep can be
+// written as one argument or as several: ["sh","-c","sleep 10"] and
+// ["sleep","10"] both wait ten seconds.
+func preStopSeconds(node *yaml.Node) (int, bool) {
+	var words []string
+	var walk func(*yaml.Node)
+	walk = func(n *yaml.Node) {
+		if n == nil {
+			return
+		}
+		if n.Kind == yaml.ScalarNode {
+			words = append(words, n.Value)
+		}
+		for _, child := range n.Content {
+			walk(child)
+		}
+	}
+	walk(node)
+
+	m := preStopSleep.FindStringSubmatch(strings.Join(words, " "))
+	if m == nil {
+		return 0, false
+	}
+	seconds, err := strconv.Atoi(m[1])
+	if err != nil {
+		return 0, false
+	}
+	return seconds, true
+}
+
+// lineOf locates a key for a finding's position. A miss reports line 1 rather
+// than failing: the position is where to look, and the message is the finding.
+func lineOf(content []byte, key string) int {
+	for i, l := range strings.Split(string(content), "\n") {
+		if strings.Contains(l, key) && !strings.HasPrefix(strings.TrimSpace(l), "#") {
+			return i + 1
+		}
+	}
+	return 1
+}
+
+// readRepoFile reads a file relative to the scanned root, reporting absence
+// rather than failing on it: the checks run over fixtures that carry only what
+// the check under test needs.
+func readRepoFile(s *snapshot, rel string) ([]byte, bool, error) {
+	b, err := os.ReadFile(filepath.Join(s.Root, filepath.FromSlash(rel)))
+	switch {
+	case errors.Is(err, os.ErrNotExist):
+		return nil, false, nil
+	case err != nil:
+		return nil, false, err
+	}
+	return b, true, nil
+}
+
+// composeFiles are the names Docker Compose looks for, in its own order of
+// preference.
+var composeFiles = []string{"compose.yaml", "compose.yml", "docker-compose.yaml", "docker-compose.yml"}
+
+// composeDuration matches the durations compose accepts for
+// stop_grace_period: a bare number of seconds, or hours, minutes and seconds
+// in that order.
+var composeDuration = regexp.MustCompile(`^(?:(\d+)h)?(?:(\d+)m)?(?:(\d+)s?)?$`)
+
+// findComposeServices reports the stop_grace_period of every compose service
+// that runs this repository's own image.
+//
+// Only those services. The grace period of a database or a cache alongside it
+// is not this process's shutdown budget, and reporting one against the other
+// would be arithmetic about two unrelated things.
+func findComposeServices(s *snapshot) ([]stopSite, error) {
+	var out []stopSite
+	for _, name := range composeFiles {
+		raw, ok, err := readRepoFile(s, name)
+		if err != nil {
+			return nil, err
+		}
+		if !ok {
+			continue
+		}
+
+		var root yaml.Node
+		if err := yaml.Unmarshal(raw, &root); err != nil {
+			return nil, fmt.Errorf("%s: %w", name, err)
+		}
+		if len(root.Content) == 0 {
+			continue
+		}
+		services := mapValue(root.Content[0], "services")
+		if services == nil {
+			continue
+		}
+
+		for i := 0; i+1 < len(services.Content); i += 2 {
+			key, service := services.Content[i], services.Content[i+1]
+			if !runsThisRepo(service, s.ModulePath) {
+				continue
+			}
+			site := stopSite{
+				file:    name,
+				line:    key.Line,
+				what:    fmt.Sprintf("service %s, which sets no stop_grace_period,", key.Value),
+				compose: true,
+			}
+			if grace := mapValue(service, "stop_grace_period"); grace != nil {
+				seconds, ok := composeSeconds(grace.Value)
+				if !ok {
+					// A duration this cannot read is left alone rather than
+					// guessed at: compose knows what it means, and inventing a
+					// number here would report against a value nobody wrote.
+					continue
+				}
+				site.line = grace.Line
+				site.what = fmt.Sprintf("stop_grace_period on service %s", key.Value)
+				site.seconds, site.set = seconds, true
+			}
+			out = append(out, site)
+		}
+	}
+	return out, nil
+}
+
+// runsThisRepo reports whether a compose service starts the image this
+// repository builds - by building it, or by naming it.
+func runsThisRepo(service *yaml.Node, modulePath string) bool {
+	if mapValue(service, "build") != nil {
+		return true
+	}
+	image := mapValue(service, "image")
+	if image == nil {
+		return false
+	}
+	repository := image.Value
+	if i := strings.LastIndex(repository, ":"); i > strings.LastIndex(repository, "/") {
+		repository = repository[:i]
+	}
+	return baseName(repository) == baseName(modulePath)
+}
+
+func baseName(path string) string {
+	if i := strings.LastIndex(path, "/"); i >= 0 {
+		return path[i+1:]
+	}
+	return path
+}
+
+func composeSeconds(value string) (int, bool) {
+	m := composeDuration.FindStringSubmatch(strings.TrimSpace(value))
+	if m == nil || m[1]+m[2]+m[3] == "" {
+		return 0, false
+	}
+	var total int
+	for i, unit := range []int{3600, 60, 1} {
+		if m[i+1] == "" {
+			continue
+		}
+		n, err := strconv.Atoi(m[i+1])
+		if err != nil {
+			return 0, false
+		}
+		total += n * unit
+	}
+	return total, true
+}
+
+// mapValue returns the value a mapping node holds for key.
+func mapValue(node *yaml.Node, key string) *yaml.Node {
+	if node == nil || node.Kind != yaml.MappingNode {
+		return nil
+	}
+	for i := 0; i+1 < len(node.Content); i += 2 {
+		if node.Content[i].Value == key {
+			return node.Content[i+1]
+		}
+	}
+	return nil
+}

--- a/tools/checksilent/shutdownbudget_test.go
+++ b/tools/checksilent/shutdownbudget_test.go
@@ -1,0 +1,484 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// hostConfigSource is the part of config/extend.go this check reads: the
+// fallbacks it applies to whatever the settings file leaves out.
+const hostConfigSource = `package config
+
+const (
+	DefaultDrainSeconds   = 0
+	DefaultServerSeconds  = 5
+	DefaultCleanupSeconds = 3
+)
+`
+
+// factorySettings is what this repository ships: 0 + 5 + 3.
+const factorySettings = "settings:\n  extend:\n    shutdown:\n      drain: 0\n      server: 5\n      cleanup: 3\n"
+
+func settingsWith(shutdown string) string {
+	return "settings:\n  extend:\n" + shutdown
+}
+
+// deployWith builds a manifest with the given container extras and pod-level
+// lines, in the shape the shipped one has.
+func deployWith(containerExtra, podExtra string) string {
+	return `---
+apiVersion: v1
+kind: Service
+metadata:
+  name: go-admin
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: go-admin-v1
+spec:
+  replicas: 1
+  template:
+    spec:
+      containers:
+      - name: go-admin
+        image: go-admin
+` + containerExtra + podExtra
+}
+
+func graceOf(seconds string) string {
+	return "      terminationGracePeriodSeconds: " + seconds + "\n"
+}
+
+const preStopSleep25 = `        lifecycle:
+          preStop:
+            exec:
+              command: ["sh", "-c", "sleep 25"]
+`
+
+// The six scenarios worked through in the technical plan, plus the one that
+// only fails when preStop is left out of the sum.
+//
+// The values matter. "raise server to 25" gives 28, which is under a grace
+// period of 30 and reaches only the WARN level - it would not show that the
+// ERROR level works at all.
+func TestShutdownBudgetAgainstTheGracePeriod(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		settings string
+		deploy   string
+		want     Severity
+		contains string
+	}{
+		{
+			name:     "the shipped defaults, with headroom",
+			settings: factorySettings,
+			deploy:   deployWith("", graceOf("30")),
+			want:     -1,
+		},
+		{
+			// The one this check exists for: drain is the interesting knob and
+			// the grace period is in another directory, so raising one and not
+			// the other is the natural mistake.
+			name:     "the budget was raised and the manifest was not",
+			settings: settingsWith("    shutdown:\n      drain: 0\n      server: 30\n      cleanup: 3\n"),
+			deploy:   deployWith("", graceOf("30")),
+			want:     Error,
+			contains: "preStop 0 + drain 0 + server 30 + cleanup 3",
+		},
+		{
+			// Equal is not a fit: the grace period is when SIGKILL is sent, so
+			// a budget that ends exactly then leaves nothing time to return.
+			name:     "the grace period was lowered to the budget",
+			settings: factorySettings,
+			deploy:   deployWith("", graceOf("8")),
+			want:     Error,
+		},
+		{
+			name:     "fits, but with nothing to spare",
+			settings: factorySettings,
+			deploy:   deployWith("", graceOf("12")),
+			want:     Warn,
+			contains: "leaves under 5s of headroom",
+		},
+		{
+			// The hook is spent before the process is told anything, so it is
+			// added to the budget rather than overlapping it.
+			name:     "a preStop hook is part of the budget",
+			settings: factorySettings,
+			deploy:   deployWith(preStopSleep25, graceOf("30")),
+			want:     Error,
+			contains: "preStop 25 + drain 0 + server 5 + cleanup 3",
+		},
+		{
+			// The example from the review: 10 + 10 + 5 + 3 against 30.
+			name:     "preStop and a drain window together, just fitting",
+			settings: settingsWith("    shutdown:\n      drain: 10\n      server: 5\n      cleanup: 3\n"),
+			deploy: deployWith(`        lifecycle:
+          preStop:
+            exec:
+              command: ["sleep", "10"]
+`, graceOf("30")),
+			want: Warn,
+		},
+		{
+			name:     "no shutdown section",
+			settings: settingsWith("    rateLimit:\n      inboundQPS: 200\n"),
+			deploy:   deployWith("", graceOf("30")),
+			want:     -1,
+		},
+		{
+			// Nothing to disagree with. A manifest without a grace period gets
+			// the Kubernetes default, which this file cannot see, and guessing
+			// at it would make the check wrong rather than quiet.
+			name:     "the manifest sets no grace period",
+			settings: settingsWith("    shutdown:\n      drain: 300\n"),
+			deploy:   deployWith("", ""),
+			want:     -1,
+		},
+		{
+			// config.Shutdown.Budget refuses this and the server does not
+			// start, so it is not a failure that passes unnoticed - and adding
+			// a negative into the sum would understate it.
+			name:     "a negative budget is left to the run-time refusal",
+			settings: settingsWith("    shutdown:\n      drain: -100\n      server: 5\n      cleanup: 3\n"),
+			deploy:   deployWith("", graceOf("5")),
+			want:     -1,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			root := fixture(t, map[string]string{
+				"config/extend.go":       hostConfigSource,
+				"config/settings.yml":    tc.settings,
+				"scripts/k8s/deploy.yml": tc.deploy,
+			})
+			got := only(t, check(t, root, options{}), checkShutdownGrace)
+			if tc.want < 0 {
+				if len(got) != 0 {
+					t.Fatalf("reported %d findings, want none:\n%v", len(got), got)
+				}
+				return
+			}
+			if len(got) != 1 {
+				// An ERROR also satisfies the WARN condition, so a second
+				// finding here means the two levels were not made exclusive -
+				// and an ERROR that always drags a duplicate WARN behind it
+				// teaches people to skip WARNs.
+				t.Fatalf("reported %d findings, want exactly 1:\n%v", len(got), got)
+			}
+			if got[0].severity != tc.want {
+				t.Errorf("reported %s, want %s: %s", got[0].Severity, tc.want, got[0].Message)
+			}
+			if tc.contains != "" && !strings.Contains(got[0].Message, tc.contains) {
+				t.Errorf("message %q does not contain %q", got[0].Message, tc.contains)
+			}
+			if got[0].File != k8sDeployFile {
+				t.Errorf("reported against %s, want %s", got[0].File, k8sDeployFile)
+			}
+			if want := lineOf([]byte(tc.deploy), "terminationGracePeriodSeconds:"); got[0].Line != want {
+				t.Errorf("reported line %d, want %d", got[0].Line, want)
+			}
+		})
+	}
+}
+
+// A hook whose duration cannot be read is said out loud rather than counted as
+// nothing. It is still spent inside the grace period, and a self-check that
+// silently valued it at zero would be the understatement this check exists to
+// prevent.
+func TestAnUnreadablePreStopIsReported(t *testing.T) {
+	root := fixture(t, map[string]string{
+		"config/extend.go":    hostConfigSource,
+		"config/settings.yml": factorySettings,
+		"scripts/k8s/deploy.yml": deployWith(`        lifecycle:
+          preStop:
+            httpGet:
+              path: /drain
+              port: 8000
+`, graceOf("30")),
+	})
+	got := only(t, check(t, root, options{}), checkShutdownGrace)
+	if len(got) != 1 {
+		t.Fatalf("reported %d findings, want 1:\n%v", len(got), got)
+	}
+	if got[0].severity != Warn {
+		t.Errorf("reported %s, want WARN", got[0].Severity)
+	}
+	if !strings.Contains(got[0].Message, "not a sleep") {
+		t.Errorf("message %q does not say why the hook could not be read", got[0].Message)
+	}
+}
+
+// Either file missing means there is nothing to compare, which is the state
+// every other check's fixture is in.
+func TestShutdownBudgetIsSkippedWithoutBothFiles(t *testing.T) {
+	for _, files := range []map[string]string{
+		{"config/extend.go": hostConfigSource},
+		{"config/extend.go": hostConfigSource, "config/settings.yml": settingsWith("    shutdown:\n      drain: 300\n")},
+		{"config/extend.go": hostConfigSource, "scripts/k8s/deploy.yml": deployWith("", graceOf("30"))},
+	} {
+		root := fixture(t, files)
+		if got := only(t, check(t, root, options{}), checkShutdownGrace); len(got) != 0 {
+			t.Errorf("reported %d findings with only %d file(s):\n%v", len(got), len(files), got)
+		}
+	}
+}
+
+// A tool that cannot find the defaults it is meant to apply has to say so.
+// Reporting nothing would be the failure this whole tool is about: a check
+// that stops checking and goes on printing a clean run.
+func TestShutdownBudgetStopsWhenTheFallbacksAreGone(t *testing.T) {
+	root := fixture(t, map[string]string{
+		"config/extend.go":       "package config\n\nconst DefaultDrainSeconds = 0\n",
+		"config/settings.yml":    settingsWith("    shutdown:\n      drain: 1\n"),
+		"scripts/k8s/deploy.yml": deployWith("", graceOf("30")),
+	})
+	s, err := load(root)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if _, err := runChecks(s, options{}); err == nil {
+		t.Fatal("runChecks succeeded with the fallback constants renamed away")
+	} else if !strings.Contains(err.Error(), serverConstName) {
+		t.Errorf("error %q does not name the missing constant", err)
+	}
+}
+
+// The same arithmetic and the same margin as the manifest check, against the
+// other place a shutdown gets cut short.
+func TestDockerStopAgainstTheShutdownBudget(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		script   string
+		want     Severity
+		contains string
+	}{
+		{
+			name:   "explicit and generous",
+			script: "sudo docker stop --timeout 30 \"$PREV\"\n",
+			want:   -1,
+		},
+		{
+			// --time is the deprecated spelling of the same flag and docker
+			// still honours it. A check that could not read it would report a
+			// deadline that exists as missing, and push whoever fixed that
+			// towards a flag that is on its way out.
+			name:   "the deprecated spelling still counts",
+			script: "docker stop --time 30 go-admin\n",
+			want:   -1,
+		},
+		{
+			name:   "the short form counts too",
+			script: "docker stop -t 30 go-admin\n",
+			want:   -1,
+		},
+		{
+			// docker's default is 10 and this process spends 8, so it happens
+			// to work today - and would stop working the first time anybody
+			// configures a drain window, without the command changing.
+			name:     "no deadline at all",
+			script:   "sudo docker stop \"$PREV\" >/dev/null\n",
+			want:     Error,
+			contains: "Pass --timeout 13",
+		},
+		{
+			name:     "shorter than the shutdown",
+			script:   "docker stop --timeout 5 go-admin\n",
+			want:     Error,
+			contains: "allows 5 seconds and this shutdown takes 8",
+		},
+		{
+			// Quoted back in the spelling that was written, so the message
+			// cannot misreport the line it is pointing at.
+			name:     "the message quotes the flag that was used",
+			script:   "docker stop -t 5 go-admin\n",
+			want:     Error,
+			contains: "`docker stop -t 5`",
+		},
+		{
+			name:   "longer than the shutdown but inside the margin",
+			script: "docker stop --timeout=10 go-admin\n",
+			want:   Warn,
+		},
+		{
+			name:   "exactly the margin",
+			script: "docker stop --timeout 13 go-admin\n",
+			want:   -1,
+		},
+		{
+			// The settings file describes `docker stop` in prose right beside
+			// the budget this check reads.
+			name:   "a commented-out command is not one that runs",
+			script: "# docker stop go-admin\n",
+			want:   -1,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			root := fixture(t, map[string]string{
+				"config/extend.go":    hostConfigSource,
+				"config/settings.yml": factorySettings,
+				"scripts/deploy.sh":   "#!/bin/sh\n" + tc.script,
+			})
+			got := only(t, check(t, root, options{}), checkDockerStop)
+			if tc.want < 0 {
+				if len(got) != 0 {
+					t.Fatalf("reported %d findings, want none:\n%v", len(got), got)
+				}
+				return
+			}
+			if len(got) != 1 {
+				t.Fatalf("reported %d findings, want 1:\n%v", len(got), got)
+			}
+			if got[0].severity != tc.want {
+				t.Errorf("reported %s, want %s: %s", got[0].Severity, tc.want, got[0].Message)
+			}
+			if tc.contains != "" && !strings.Contains(got[0].Message, tc.contains) {
+				t.Errorf("message %q does not contain %q", got[0].Message, tc.contains)
+			}
+			if got[0].File != "scripts/deploy.sh" || got[0].Line != 2 {
+				t.Errorf("reported %s:%d, want scripts/deploy.sh:2", got[0].File, got[0].Line)
+			}
+		})
+	}
+}
+
+func composeWith(service string) string {
+	return "version: '3.8'\nservices:\n" + service
+}
+
+// The compose file is the other way this repository's container is stopped -
+// `make run` starts it that way - and it fails identically: the default is ten
+// seconds and it is nowhere near the budget it has to cover.
+func TestComposeStopGraceAgainstTheShutdownBudget(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		service  string
+		want     Severity
+		contains string
+	}{
+		{
+			name:    "generous",
+			service: "  api:\n    image: go-admin:latest\n    stop_grace_period: 30s\n",
+			want:    -1,
+		},
+		{
+			name:     "not set at all",
+			service:  "  api:\n    image: go-admin:latest\n",
+			want:     Error,
+			contains: "Set stop_grace_period: 13s",
+		},
+		{
+			name:     "shorter than the shutdown",
+			service:  "  api:\n    image: go-admin:latest\n    stop_grace_period: 5s\n",
+			want:     Error,
+			contains: "stop_grace_period on service api allows 5 seconds",
+		},
+		{
+			name:    "longer than the shutdown but inside the margin",
+			service: "  api:\n    image: go-admin:latest\n    stop_grace_period: 10s\n",
+			want:    Warn,
+		},
+		{
+			// Compose takes hours and minutes as well as seconds, and a check
+			// that only read the digits would call 1m30s ninety times too
+			// short.
+			name:    "minutes and seconds",
+			service: "  api:\n    image: go-admin:latest\n    stop_grace_period: 1m30s\n",
+			want:    -1,
+		},
+		{
+			// A service running something else is not this process, and its
+			// grace period has nothing to do with this budget.
+			name:    "another image is not this application",
+			service: "  db:\n    image: mysql:8\n",
+			want:    -1,
+		},
+		{
+			// Built from this repository, so it is this application whatever
+			// the image ends up being called.
+			name:     "built here rather than named",
+			service:  "  api:\n    build: .\n",
+			want:     Error,
+			contains: "service api, which sets no stop_grace_period",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			root := fixture(t, map[string]string{
+				"config/extend.go":    hostConfigSource,
+				"config/settings.yml": factorySettings,
+				"docker-compose.yml":  composeWith(tc.service),
+			})
+			got := only(t, check(t, root, options{}), checkDockerStop)
+			if tc.want < 0 {
+				if len(got) != 0 {
+					t.Fatalf("reported %d findings, want none:\n%v", len(got), got)
+				}
+				return
+			}
+			if len(got) != 1 {
+				t.Fatalf("reported %d findings, want 1:\n%v", len(got), got)
+			}
+			if got[0].severity != tc.want {
+				t.Errorf("reported %s, want %s: %s", got[0].Severity, tc.want, got[0].Message)
+			}
+			if tc.contains != "" && !strings.Contains(got[0].Message, tc.contains) {
+				t.Errorf("message %q does not contain %q", got[0].Message, tc.contains)
+			}
+			if got[0].File != "docker-compose.yml" {
+				t.Errorf("reported against %s, want docker-compose.yml", got[0].File)
+			}
+		})
+	}
+}
+
+func TestComposeDurations(t *testing.T) {
+	for _, tc := range []struct {
+		in     string
+		want   int
+		wantOK bool
+	}{
+		{in: "30s", want: 30, wantOK: true},
+		{in: "30", want: 30, wantOK: true},
+		{in: "1m30s", want: 90, wantOK: true},
+		{in: "2m", want: 120, wantOK: true},
+		{in: "1h", want: 3600, wantOK: true},
+		{in: "1h0m30s", want: 3630, wantOK: true},
+		{in: "", wantOK: false},
+		{in: "forever", wantOK: false},
+		{in: "500ms", wantOK: false},
+	} {
+		t.Run(tc.in, func(t *testing.T) {
+			got, ok := composeSeconds(tc.in)
+			if ok != tc.wantOK {
+				t.Fatalf("composeSeconds(%q) ok = %v, want %v", tc.in, ok, tc.wantOK)
+			}
+			if ok && got != tc.want {
+				t.Errorf("composeSeconds(%q) = %d, want %d", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+// The command can be written in a workflow or in the Makefile as easily as in
+// a shell script, and a check that only looked at one of them would be quiet
+// about the others.
+func TestDockerStopIsFoundInEveryKindOfFile(t *testing.T) {
+	root := fixture(t, map[string]string{
+		"config/extend.go":           hostConfigSource,
+		"config/settings.yml":        factorySettings,
+		".github/workflows/ship.yml": "jobs:\n  deploy:\n    steps:\n      - run: docker stop app\n",
+		"Makefile":                   "stop:\n\tdocker stop app\n",
+		"scripts/deploy.sh":          "docker stop app\n",
+	})
+	got := only(t, check(t, root, options{}), checkDockerStop)
+	if len(got) != 3 {
+		t.Fatalf("found %d commands, want 3:\n%v", len(got), got)
+	}
+}
+
+func TestLineOfIgnoresComments(t *testing.T) {
+	content := []byte("a: 1\n  # terminationGracePeriodSeconds: 99\n  terminationGracePeriodSeconds: 30\n")
+	if got := lineOf(content, "terminationGracePeriodSeconds:"); got != 3 {
+		t.Errorf("lineOf = %d, want 3 - a commented-out key is not the setting", got)
+	}
+}


### PR DESCRIPTION
#908 给了 `/ready`，让它在关闭一开始就返回 503。**实测下来那个 503 采不到** —— `health.BeginDraining()` 的下一句就是 `srv.Shutdown()`，两者相隔微秒，秒级轮询的东西永远看不见。

本 PR 在两者之间放一段**可配置的排空窗口**，期间进程照常服务。

## 为什么不是「加个 sleep」

三份并行评审推翻了原方案的两处**因果模型**，不是写法：

**① 子进程测试从不调用 `run()`**（`grep -c "run()" cmd/api/signal_test.go` = 0）。它重写了一份关闭序列并断言自己那份 —— 把 `BeginDraining()` 挪到 sleep 之后，产线退回缺陷，测试一个字都不会变红。而 PRD 写着它是「唯一能证明修复真的生效的断言」。

**所以第 1 条提交是抽出 `gracefulShutdown()`**，让 `run()` 和子进程测试共用同一份序列。其余每一条断言都建立在它之上。

**② k8s 上摘除不由探针驱动。** Pod 被删时 `deletionTimestamp` 一置上，endpoints controller 就摘除，与 SIGTERM 并发，跟 readiness 返回什么无关。所以文档按拓扑分两段写：外部 LB 轮询 `/ready` 的模型成立；k8s 上 drain 覆盖的是**摘除的传播延迟**，503 的作用是让人能观察到。

## 关闭序列

```
<-quit
BeginShutdown() → BeginDraining() → SetKeepAlivesEnabled(false)
──────────────── 排空窗口，仍在正常服务 ────────────────
select { case <-quit: 提前结束 ; case <-time.After(drain): }
────────────────────────────────────────────────────
disarmStopSignals() → Shutdown() → RunShutdown()
```

三处不显然的地方：

- **`disarmStopSignals()` 挪到窗口之后**。原位置让整段 drain 落在「第二个 SIGTERM 直接杀进程」的区间里 —— 改之前那个区间只在钩子卡死时才踩得到，改之后**每次常规关闭都要在里面待 N 秒**。窗口内信号保持 armed，第二个信号被收下并**提前结束排空**。
- **`SetKeepAlivesEnabled(false)`**。`doKeepAlives()` 是 `!disableKeepAlives.Load() && !shuttingDown()`，而 `shuttingDown()` 只在 `Shutdown()` 里才置位 —— 不显式关掉，窗口内 LB 连接池纹丝不动，成本付了收益没拿。它还顺带 `closeIdleConns()`。
- **探针绕开限流器**。`r.Use(common.Sentinel())` 挂在 engine 上，超限返 429 —— 流量冲高 → liveness 拿 429 → 三次失败 → 容器被重启 → 容量下降。**限流器正常工作恰恰是 Pod 被杀的原因。**

## 配置

落在 `extend.shutdown`，不是 `application.shutdown` —— core 的 `Application` 是固定 9 字段 struct，`json.Unmarshal` 静默丢弃未知字段，**写了等于没写且不报错**。

```yaml
extend:
  shutdown:
    drain: 0      # 默认 0：不配置则行为与升级前完全一致
    server: 5
    cleanup: 3
```

三个字段都是 `*int`：`nil` 回退默认值，**显式写 0 一律按字面执行**。这让 `server: 0`（不等在途请求，立刻退）可表达，也让三者的零值语义统一，不需要「这一项例外」的文档。同仓先例是 `RateLimit.InboundQPS *float64`。负数拒绝并报错，不静默钳到 0。

## 三条停止路径都要给够时间

`docker stop` 默认 10 秒，而 `server`+`cleanup` 已经是 8 秒 —— **配 drain > 2 就会被 SIGKILL 截断**。三处全改：发布工作流 `--time 30`、compose `stop_grace_period: 30s`、`make run` 里那句 `docker rm -f`（force 是 SIGKILL、零宽限，本地重启把每一次关闭都砍断）。

配套两条 checksilent 检查盯着它们，共用一条算术和一个 5 秒边际：超限是 ERROR，余量不足是 WARN，两者互斥。`preStop` 进公式（自带清单没有钩子，但以后有人加一段 sleep，看不见它的自检会把真实预算低估那么多）。`stop_grace_period` 按 duration 解析而不是读数字 —— compose 收 `1m30s`，只读首个数字会把 90 秒当成 1 秒。

## 验证

`go build` / `go vet` / `make checksilent` / `go test -race -count=1 ./...` 退出码全 0，24 个包通过。**每一条提交之后都跑过这三条命令，没有一条编译不过或跑红。**

**18 条反证逐条真的跑红过**，且每条都经过分类器判定，不是肉眼看 `--- FAIL`：

| 反证 | 红在哪 |
|---|---|
| `BeginDraining()` 挪到窗口之后 | `no answer inside the window reported draining` |
| 去掉 `SetKeepAlivesEnabled(false)` | `answers inside the window still kept the connection alive` |
| 去掉 `case <-quit` | `the window ran its full 10s despite a second signal` |
| 默认 drain 改成非 0 | `an unconfigured shutdown spent 1.0015795s; must be immediate` |
| 去掉探针豁免 | `answered 429; a probe that can be rate-limited gets the container restarted` |
| preStop 从公式去掉 | `reported 0 findings, want exactly 1` |
| 只查 build.yml 不查 compose | `reported 0 findings, want 1` |

**A2 的判据锚在响应体上，不是状态码。** 子进程测试不接数据库，`health.Ready` 无配置时两条检查都失败，`/ready` 从启动那一刻就一直返回 503 —— 只断言状态码的话，把 `BeginDraining()` 整行删掉测试照样绿。反证的失败输出逐行打着 `/api/v1/ready -> 503 draining=false`：503 在，draining 不在。

覆盖率：`config` 100.0%、`tools/checksilent` 88.3%、`common/health` 81.0%。

## 顺带订正的表述

#908 在三处注释里写「readiness 转 fail 让 LB 有机会在连接被切断前摘走实例」。[#910](https://github.com/go-admin-team/go-admin/pull/910) 已经把它改成「顺序必要但不充分」；本 PR 给了那个窗口，所以再改一次，并**保住前提**：默认 `drain: 0`，未配置的部署上「只能读、没人据此行动」依然成立。

一次不带预设范围的全仓扫描（含 `_test.go`、文档、配置、Makefile、shell、中英两种表述）查出 24 处相关表述，逐条判过。其中 `common/health/health_test.go` 那处是这次才发现的 —— 此前所有清单列的都是产线 `.go` 和文档，没有人扫过测试文件。

## 已知不覆盖的

- **`docker rm -f`**：按定义零宽限，没有数字可比，检查不管它。保证那条路径安全的是 `Makefile` 里那行本身，不是检查。工作流里剩下的三处 `rm -f` 对已停止容器和回滚路径用，静态分不出容器是否在跑。
- **窗口内的配置热重载**：`BeginShutdown` 挡住的是阶段宣告，不是 `database.Setup`/`storage.Setup` 本身重跑 —— 窗口把这个空洞从微秒放大到 N 秒。已记 [go-admin-core#152](https://github.com/go-admin-team/go-admin-core/issues/152)，本批次不修。
- **退出时队列不排空**：core v2.7.0 能排空了，但没有地方调用它。已记 [#911](https://github.com/go-admin-team/go-admin/issues/911)。

## 自带清单保持单副本

`replicas: 1` 不动，并写明原因。挡住提副本数的不是评审说的「撞 RWO 的 PVC」（`storage.yml` 实际是 `ReadWriteMany`），而是 `Dockerfile` 没有 `WORKDIR`，`logger.path: temp/logs` 解析成 `/temp/logs`，而 `/temp` 正是那个共享 PVC —— 两副本会让两个 lumberjack 往 NFS 上同一个文件轮转写。
