### PR TITLE
fix🐛: demo 模式放行了注册成 GET 的写接口

### DIFF
--- a/app/other/router/demo_guard_test.go
+++ b/app/other/router/demo_guard_test.go
@@ -1,0 +1,75 @@
+package router
+
+import (
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	jwt "github.com/go-admin-team/go-admin-core/v2/jwtauth"
+
+	"go-admin/common/middleware"
+)
+
+// registeredRoutes builds the generator's routes on an engine of its own and
+// reports the patterns they were registered under.
+//
+// The JWT middleware is a zero value. MiddlewareFunc only closes over the
+// receiver and is never called here - no request is served, the engine is
+// asked what it has - so nothing dereferences it.
+func registeredRoutes(t *testing.T) map[string]bool {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+
+	r := gin.New()
+	v1 := r.Group("/api/v1")
+	sysNoCheckRoleRouter(v1, &jwt.GinJWTMiddleware{})
+	registerDBRouter(v1, &jwt.GinJWTMiddleware{})
+
+	out := map[string]bool{}
+	for _, route := range r.Routes() {
+		out[route.Path] = true
+	}
+	return out
+}
+
+// The list of routes demo mode refuses lives in common/middleware, which may
+// not import app/ and therefore cannot see whether any of them is still a
+// route. This is the half that can be checked, and it is checked here because
+// this is where the routes are declared: rename one, and the entry over there
+// stops matching anything, demo mode silently starts serving it again, and
+// nothing else would say so.
+func TestEveryRouteDemoModeRefusesStillExists(t *testing.T) {
+	routes := registeredRoutes(t)
+	for _, guarded := range middleware.DemoWriteRoutes() {
+		if !routes[guarded] {
+			t.Errorf("demo mode refuses %q, but no route is registered under that pattern - "+
+				"either it was renamed, or it moved to another file; the guard now matches nothing",
+				guarded)
+		}
+	}
+}
+
+// The other direction, and the one the demo host cares about: the generator's
+// read-only routes have to stay reachable, or a demo deployment cannot show
+// the feature at all. Refusing too much is as much of a defect as refusing too
+// little.
+func TestTheGeneratorsReadOnlyRoutesAreNotRefused(t *testing.T) {
+	refused := map[string]bool{}
+	for _, guarded := range middleware.DemoWriteRoutes() {
+		refused[guarded] = true
+	}
+
+	for _, readOnly := range []string{
+		"/api/v1/gen/preview/:tableId",
+		"/api/v1/gen/tabletree",
+		"/api/v1/db/tables/page",
+		"/api/v1/db/columns/page",
+	} {
+		if !registeredRoutes(t)[readOnly] {
+			t.Fatalf("%s is not registered, so this test is asserting against nothing", readOnly)
+		}
+		if refused[readOnly] {
+			t.Errorf("demo mode refuses %s, which only reads - the demo host needs it to "+
+				"demonstrate the generator", readOnly)
+		}
+	}
+}

--- a/common/middleware/demo.go
+++ b/common/middleware/demo.go
@@ -1,29 +1,103 @@
 package middleware
 
 import (
+	"net/http"
+
 	"github.com/gin-gonic/gin"
 	"github.com/go-admin-team/go-admin-core/v2/sdk/config"
-	"net/http"
 )
 
+// defaultDemoMsg is what a refused request is told when nothing is configured.
+//
+// It is the string this middleware used to carry hard-coded, kept verbatim so
+// that a deployment which never set application.demomsg is answered exactly as
+// it was before.
+const defaultDemoMsg = "谢谢您的参与，但为了大家更好的体验，所以本次提交就算了吧！\U0001F600\U0001F600\U0001F600"
+
+// demoWriteRoutes are routes that change something despite being registered as
+// GET, so the method alone does not say whether they are safe to serve.
+//
+// All three belong to the code generator: two write Go source files onto the
+// server's filesystem and the third inserts menus, APIs and casbin rules into
+// the database. They are registered under a group whose own name says it does
+// no role check, and a demo deployment lets anybody log in - so on a demo host
+// they were reachable by any visitor, and the menus one had in fact been used.
+//
+// Spelled as gin route patterns, which is what Context.FullPath returns, so a
+// path parameter matches whatever value it is given.
+//
+// This list cannot be checked from here: common/ may not import app/, so this
+// package cannot see which routes exist. What keeps it honest is a test beside
+// the routes themselves - see app/other/router - which registers them and
+// fails if any entry here has stopped being a real route.
+//
+// It also does not close the general hole. Nothing stops the next GET handler
+// that writes something from being added without an entry here, and no static
+// check can tell a handler that writes from one that reads. Demo mode refuses
+// the routes it has been told about; that is the whole of the guarantee.
+var demoWriteRoutes = map[string]bool{
+	"/api/v1/gen/toproject/:tableId": true,
+	"/api/v1/gen/apitofile/:tableId": true,
+	"/api/v1/gen/todb/:tableId":      true,
+}
+
+// DemoWriteRoutes returns the routes demo mode refuses despite their method.
+//
+// Exported only so the test that lives beside the route registrations can
+// check every one of them still exists; nothing else should need it.
+func DemoWriteRoutes() []string {
+	out := make([]string, 0, len(demoWriteRoutes))
+	for route := range demoWriteRoutes {
+		out = append(out, route)
+	}
+	return out
+}
+
+// demoAllows reports whether demo mode lets a request through.
+//
+// route is the matched gin route pattern and uri the raw request target; the
+// two are different things and both are needed. The route is what identifies a
+// handler regardless of the values in its path parameters, and it is empty for
+// a request that matched nothing - which is why the login and logout checks
+// still read the raw target, as they always did.
+func demoAllows(method, route, uri string) bool {
+	if demoWriteRoutes[route] {
+		return false
+	}
+	return method == http.MethodGet ||
+		method == http.MethodOptions ||
+		uri == "/api/v1/login" ||
+		uri == "/api/v1/logout"
+}
+
+// demoMessage is the answer a refused request gets.
+//
+// application.demomsg has been in the configuration all along and nothing read
+// it: the message was hard-coded here, and the demo host's configured string
+// happened to be identical, so the setting looked like it worked. An empty
+// value falls back rather than answering with nothing.
+func demoMessage() string {
+	if msg := config.ApplicationConfig.DemoMsg; msg != "" {
+		return msg
+	}
+	return defaultDemoMsg
+}
+
+// DemoEvn refuses anything that would change state while mode is demo.
 func DemoEvn() gin.HandlerFunc {
 	return func(c *gin.Context) {
-		method := c.Request.Method
-		if config.ApplicationConfig.Mode == "demo" {
-			if method == "GET" ||
-				method == "OPTIONS" ||
-				c.Request.RequestURI == "/api/v1/login" ||
-				c.Request.RequestURI == "/api/v1/logout" {
-				c.Next()
-			} else {
-				c.JSON(http.StatusOK, gin.H{
-					"code": 500,
-					"msg":  "谢谢您的参与，但为了大家更好的体验，所以本次提交就算了吧！\U0001F600\U0001F600\U0001F600",
-				})
-				c.Abort()
-				return
-			}
+		if config.ApplicationConfig.Mode != "demo" {
+			c.Next()
+			return
 		}
-		c.Next()
+		if demoAllows(c.Request.Method, c.FullPath(), c.Request.RequestURI) {
+			c.Next()
+			return
+		}
+		c.JSON(http.StatusOK, gin.H{
+			"code": 500,
+			"msg":  demoMessage(),
+		})
+		c.Abort()
 	}
 }

--- a/common/middleware/demo_test.go
+++ b/common/middleware/demo_test.go
@@ -1,0 +1,144 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/go-admin-team/go-admin-core/v2/sdk/config"
+)
+
+// demoMode puts the process in demo mode for one test and puts it back.
+func demoMode(t *testing.T, mode, msg string) {
+	t.Helper()
+	previousMode, previousMsg := config.ApplicationConfig.Mode, config.ApplicationConfig.DemoMsg
+	t.Cleanup(func() {
+		config.ApplicationConfig.Mode = previousMode
+		config.ApplicationConfig.DemoMsg = previousMsg
+	})
+	config.ApplicationConfig.Mode, config.ApplicationConfig.DemoMsg = mode, msg
+}
+
+// The method is not enough on its own. Three of the generator's routes are
+// registered as GET and write anyway - two of them onto the server's
+// filesystem, one into the database - so a guard that reads only the method
+// serves them to anybody who can log in, which on a demo host is everybody.
+func TestDemoRefusesTheWritesThatAreServedOverGET(t *testing.T) {
+	const login = "/api/v1/login"
+	for _, tc := range []struct {
+		name        string
+		method      string
+		route, uri  string
+		wantThrough bool
+	}{
+		{"a plain read", http.MethodGet, "/api/v1/dept", "/api/v1/dept", true},
+		{"a write, by method", http.MethodPost, "/api/v1/dept", "/api/v1/dept", false},
+		{"login is how a visitor gets in", http.MethodPost, login, login, true},
+		{"logout", http.MethodPost, "/api/v1/logout", "/api/v1/logout", true},
+		{"preflight", http.MethodOptions, "/api/v1/dept", "/api/v1/dept", true},
+		// A request that matched no route has an empty pattern, and the guard
+		// still has to refuse it by method - this is what a POST to a path
+		// that does not exist looks like from in here.
+		{"a write to nothing at all", http.MethodPost, "", "/api/v1/__probe__", false},
+
+		// The three this change is about.
+		{"generator writes the database", http.MethodGet,
+			"/api/v1/gen/todb/:tableId", "/api/v1/gen/todb/3", false},
+		{"generator writes source files", http.MethodGet,
+			"/api/v1/gen/toproject/:tableId", "/api/v1/gen/toproject/3", false},
+		{"generator writes an api file", http.MethodGet,
+			"/api/v1/gen/apitofile/:tableId", "/api/v1/gen/apitofile/3", false},
+
+		// The read-only half of the generator has to keep working, or the demo
+		// host cannot demonstrate the feature at all. Refusing too much is as
+		// much of a defect as refusing too little.
+		{"generator preview stays available", http.MethodGet,
+			"/api/v1/gen/preview/:tableId", "/api/v1/gen/preview/3", true},
+		{"generator table tree stays available", http.MethodGet,
+			"/api/v1/gen/tabletree", "/api/v1/gen/tabletree", true},
+		{"table list stays available", http.MethodGet,
+			"/api/v1/db/tables/page", "/api/v1/db/tables/page", true},
+		{"column list stays available", http.MethodGet,
+			"/api/v1/db/columns/page", "/api/v1/db/columns/page", true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := demoAllows(tc.method, tc.route, tc.uri); got != tc.wantThrough {
+				t.Errorf("demoAllows(%s %s) = %v, want %v", tc.method, tc.route, got, tc.wantThrough)
+			}
+		})
+	}
+}
+
+// Everything above is about demo mode only. A deployment that is not a demo
+// runs the generator for real, and a guard that reached it there would have
+// taken the feature away from every production install.
+func TestOutsideDemoModeNothingIsRefused(t *testing.T) {
+	demoMode(t, "prod", "")
+	gin.SetMode(gin.TestMode)
+
+	for _, route := range append(DemoWriteRoutes(), "/api/v1/dept") {
+		t.Run(route, func(t *testing.T) {
+			r := gin.New()
+			r.Use(DemoEvn())
+			r.GET(route, func(c *gin.Context) { c.String(http.StatusOK, "served") })
+
+			w := httptest.NewRecorder()
+			r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, requestFor(route), nil))
+			if w.Body.String() != "served" {
+				t.Errorf("answered %q; outside demo mode the handler must run", w.Body.String())
+			}
+		})
+	}
+}
+
+// The refusal has to come back as the demo message rather than a 403 or a 404:
+// the front end shows it to the visitor, and the point of a demo host is that
+// being turned away is explained.
+func TestDemoRefusalCarriesTheConfiguredMessage(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	const route = "/api/v1/gen/todb/:tableId"
+
+	for _, tc := range []struct {
+		name, configured, want string
+	}{
+		{"configured", "come back tomorrow", "come back tomorrow"},
+		// A deployment that never set application.demomsg keeps the answer it
+		// already had; an empty setting must not become an empty message.
+		{"not configured", "", defaultDemoMsg},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			demoMode(t, "demo", tc.configured)
+
+			r := gin.New()
+			r.Use(DemoEvn())
+			r.GET(route, func(c *gin.Context) { c.String(http.StatusOK, "served") })
+
+			w := httptest.NewRecorder()
+			r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, requestFor(route), nil))
+
+			if w.Code != http.StatusOK {
+				t.Errorf("answered %d, want 200 so the front end reads the body", w.Code)
+			}
+			if body := w.Body.String(); !strings.Contains(body, tc.want) {
+				t.Errorf("body %q does not carry %q", body, tc.want)
+			}
+			if strings.Contains(w.Body.String(), "served") {
+				t.Error("the handler ran; the request was supposed to be refused")
+			}
+		})
+	}
+}
+
+// requestFor turns a route pattern into a request target by giving every path
+// parameter a value.
+func requestFor(route string) string {
+	segments := strings.Split(route, "/")
+	for i, segment := range segments {
+		if strings.HasPrefix(segment, ":") {
+			segments[i] = "1"
+		}
+	}
+	return strings.Join(segments, "/")
+}


### PR DESCRIPTION
演示站上出现了三组自动生成的 `SysCasbinRule` 菜单(`sys_menu` 18 行,生成于 09-01 与 09-04)。查下来不是数据问题,是 demo 模式拦不住写操作。

## `DemoEvn` 按 HTTP 方法判断,而生成器的写接口是 GET

`common/middleware/demo.go` 在 demo 模式下放行所有 GET。而 `app/other/router/gen_router.go` 里这三条会写数据:

```go
r.GET("/gen/todb/:tableId",      gen.GenMenuAndApi)   // 往库里写菜单与 API
r.GET("/gen/toproject/:tableId", gen.GenCode)         // 往 GenConfig.FrontPath 下写文件
r.GET("/gen/apitofile/:tableId", gen.GenApiToFile)    // 同上
```

它们只有 JWT,没有角色校验。演示站的登录是公开的,所以任何访客都能往库里插数据、往机器上写文件 —— 那三组菜单就是这么来的。

实测确认过 demo 模式本身没坏:`POST /api/v1/__probe__` 会被拦下并返回提示,GET 直接穿过去。

## 改法:按路由模式拦,不按方法

用 `c.FullPath()` 拿 gin 的路由模式(`/api/v1/gen/todb/:tableId`),和 `CasbinExclude` 的写法一致 —— 路径参数的实际取值不影响判定。

`method` / `route` / `uri` 三个来源都用上了:路由模式能跨路径参数认出 handler,但**未匹配的请求它是空串**,所以 login / logout 仍按原来的 `RequestURI` 判,那段语义一个字没动。

**为什么不把这三条改成 POST**(那才是根治):`sys_api` 按方法 + 路径存,casbin 策略跟着方法走。方法一改,存量部署里已授权的角色会突然 403,还要配套迁移 `sys_api.action` 并重新同步策略。那是另一个决定,不在这里做。

## 只读的必须继续能用

演示站还要能演示代码生成器,所以拦的只有写的那三条:

| 路由 | demo 模式下 |
|---|---|
| `/gen/preview/:tableId` | 放行 |
| `/gen/tabletree` | 放行 |
| `/db/tables/page` · `/db/columns/page` | 放行 |
| `/gen/todb` · `/gen/toproject` · `/gen/apitofile` | **拒绝** |

拒绝时仍是 `200` + `{"code":500,"msg":...}`,前端照旧弹提示,不是 403。

## `demomsg` 此前是个死配置

`DemoEvn` 把提示串硬编码在代码里,`config.ApplicationConfig.DemoMsg` **没有任何地方读它**。演示站 `settings.yml` 里配的字符串和硬编码的恰好一样,所以一直没人发现。

现在读配置,空值回退到原串 —— 那个常量逐字节保留,没配 `demomsg` 的部署答复不变。

## 那个洞只关上了一半,另一半写在代码里

**关上的**:`app/other/router/demo_guard_test.go` 把生成器路由注册到一个 engine 上,枚举 `r.Routes()`,断言守卫列表里每一条都还是真实路由。谁改了路径,测试就红。

它放在 `app/other/router` 而不是守卫那边,是因为 `common/` 不能 import `app/`(`contract-import-boundary` 连测试文件一起管),守卫根本看不见路由存不存在。

**没关上的**:静态分不出一个 handler 写不写,所以「以后新加的 GET 写接口」枚举不出来。这句写进了 `demoWriteRoutes` 的注释,而不是假装覆盖了:

> Demo mode refuses the routes it has been told about; that is the whole of the guarantee.

## 反证:5 条,每条都真的跑红过

| 退化 | 红在哪 |
|---|---|
| 拿掉路径拦截 | `demoAllows(GET /api/v1/gen/todb/:tableId) = true, want false`,三条全红 |
| 把 `:tableId` 写成 `:tableID` | `refuses ".../:tableID", but no route is registered under that pattern` |
| **把只读的 `preview` 也加进拦截** | 两个包同时红 —— 拦过头和不拦一样是缺陷 |
| `demomsg` 不回退,空值直接返回 | 响应体不含默认串 |
| `FullPath()` 为空时提前放行 | `demoAllows(POST ) = true, want false` |

第三条是这次特意加的方向:用户的要求是「演示功能要保证正常」,把只读接口也拦掉同样是 bug。

最后一条钉的是实测里那条 `POST /api/v1/__probe__` —— 它没匹配到任何路由,`FullPath()` 是空串;防的是有人看到空串就早返回。

`TestOutsideDemoModeNothingIsRefused` 对每条写接口发真实请求,断言**非 demo 部署照常可用**。

## 验证

`go build` / `go vet` / `make checksilent` / `go test -race -count=1 ./...` 退出码全 0,25 个包通过。

## 边界

本 PR 只覆盖 demo 模式。**非 demo 的部署上,这三条仍列在 `CasbinExclude` 里**,任何已登录用户不限角色都能调 —— 那是另一个决定,这里没有触碰。
