### PR TITLE
Register the generator's writing endpoints only in a development mode

### DIFF
--- a/app/other/router/demo_guard_test.go
+++ b/app/other/router/demo_guard_test.go
@@ -16,8 +16,13 @@ import (
 // The mode has to be given rather than inherited, because it now decides what
 // gets registered: a test that leaves it at the zero value would be asking
 // about a mode no deployment runs in, and would pass whether or not the gate
-// works. The previous value is put back so the order of tests in this package
-// cannot change their answers.
+// works.
+//
+// It is put back before this returns, not at the end of the test. t.Cleanup
+// would leave the mode set for everything the caller does afterwards, so a
+// caller that went on to assert something mode-dependent would be reading a
+// value this helper left behind rather than one it chose. A caller that does
+// want the mode set has to set it, which is visible where it happens.
 //
 // The JWT middleware is a zero value. MiddlewareFunc only closes over the
 // receiver and is never called here - no request is served, the engine is
@@ -27,7 +32,7 @@ func registeredRoutes(t *testing.T, mode string) map[string]bool {
 	gin.SetMode(gin.TestMode)
 
 	previous := config.ApplicationConfig.Mode
-	t.Cleanup(func() { config.ApplicationConfig.Mode = previous })
+	defer func() { config.ApplicationConfig.Mode = previous }()
 	config.ApplicationConfig.Mode = mode
 
 	r := gin.New()

--- a/app/other/router/demo_guard_test.go
+++ b/app/other/router/demo_guard_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	jwt "github.com/go-admin-team/go-admin-core/v2/jwtauth"
+	"github.com/go-admin-team/go-admin-core/v2/sdk/config"
 
 	"go-admin/common/middleware"
 )
@@ -12,12 +13,22 @@ import (
 // registeredRoutes builds the generator's routes on an engine of its own and
 // reports the patterns they were registered under.
 //
+// The mode has to be given rather than inherited, because it now decides what
+// gets registered: a test that leaves it at the zero value would be asking
+// about a mode no deployment runs in, and would pass whether or not the gate
+// works. The previous value is put back so the order of tests in this package
+// cannot change their answers.
+//
 // The JWT middleware is a zero value. MiddlewareFunc only closes over the
 // receiver and is never called here - no request is served, the engine is
 // asked what it has - so nothing dereferences it.
-func registeredRoutes(t *testing.T) map[string]bool {
+func registeredRoutes(t *testing.T, mode string) map[string]bool {
 	t.Helper()
 	gin.SetMode(gin.TestMode)
+
+	previous := config.ApplicationConfig.Mode
+	t.Cleanup(func() { config.ApplicationConfig.Mode = previous })
+	config.ApplicationConfig.Mode = mode
 
 	r := gin.New()
 	v1 := r.Group("/api/v1")
@@ -38,7 +49,7 @@ func registeredRoutes(t *testing.T) map[string]bool {
 // stops matching anything, demo mode silently starts serving it again, and
 // nothing else would say so.
 func TestEveryRouteDemoModeRefusesStillExists(t *testing.T) {
-	routes := registeredRoutes(t)
+	routes := registeredRoutes(t, "demo")
 	for _, guarded := range middleware.DemoWriteRoutes() {
 		if !routes[guarded] {
 			t.Errorf("demo mode refuses %q, but no route is registered under that pattern - "+
@@ -64,7 +75,7 @@ func TestTheGeneratorsReadOnlyRoutesAreNotRefused(t *testing.T) {
 		"/api/v1/db/tables/page",
 		"/api/v1/db/columns/page",
 	} {
-		if !registeredRoutes(t)[readOnly] {
+		if !registeredRoutes(t, "demo")[readOnly] {
 			t.Fatalf("%s is not registered, so this test is asserting against nothing", readOnly)
 		}
 		if refused[readOnly] {

--- a/app/other/router/gen_router.go
+++ b/app/other/router/gen_router.go
@@ -11,7 +11,7 @@ func init() {
 	routerCheckRole = append(routerCheckRole, sysNoCheckRoleRouter, registerDBRouter, registerSysTableRouter)
 }
 
-func sysNoCheckRoleRouter(v1 *gin.RouterGroup ,authMiddleware *jwt.GinJWTMiddleware) {
+func sysNoCheckRoleRouter(v1 *gin.RouterGroup, authMiddleware *jwt.GinJWTMiddleware) {
 	r1 := v1.Group("")
 	{
 		sys := apis.System{}

--- a/app/other/router/gen_router.go
+++ b/app/other/router/gen_router.go
@@ -3,9 +3,43 @@ package router
 import (
 	"github.com/gin-gonic/gin"
 	jwt "github.com/go-admin-team/go-admin-core/v2/jwtauth"
+	"github.com/go-admin-team/go-admin-core/v2/sdk/config"
+
 	"go-admin/app/admin/apis"
 	"go-admin/app/other/apis/tools"
 )
+
+// GenWriteRoutesEnabled reports whether the code generator's writing endpoints
+// are registered in this process.
+//
+// Three of the generator's endpoints do not read. /gen/toproject writes seven
+// Go and Vue source files onto this host, one of them under the path
+// gen.frontpath names; /gen/apitofile writes a migration; /gen/todb inserts
+// menus and APIs. All three are GET, all three are listed in CasbinExclude,
+// and AuthCheckRole skips what is on that list - so Enforce never runs for
+// them and any account that can log in may call them. That is a bargain a
+// workstation can make and a deployment cannot.
+//
+// dev is the shipped default and is where the generator is meant to be used.
+// demo keeps them because demo mode already has a better answer than a 404:
+// DemoEvn refuses these three by name and explains itself, which is the thing
+// the demo exists to show. test and prod get nothing.
+//
+// The mode is read once, while the routes are being built. Changing
+// application.mode in a running process adds and removes nothing - a
+// configuration reload rebuilds neither the engine nor its routes.
+//
+// core has constants for dev, test and prod but none for demo, which this
+// repository spells as a literal in common/middleware/demo.go. Both are
+// literals here so that the two read as one set rather than two conventions.
+func GenWriteRoutesEnabled() bool {
+	switch config.ApplicationConfig.Mode {
+	case "dev", "demo":
+		return true
+	default:
+		return false
+	}
+}
 
 func init() {
 	routerCheckRole = append(routerCheckRole, sysNoCheckRoleRouter, registerDBRouter, registerSysTableRouter)
@@ -22,9 +56,11 @@ func sysNoCheckRoleRouter(v1 *gin.RouterGroup, authMiddleware *jwt.GinJWTMiddlew
 	{
 		gen := tools.Gen{}
 		r.GET("/gen/preview/:tableId", gen.Preview)
-		r.GET("/gen/toproject/:tableId", gen.GenCode)
-		r.GET("/gen/apitofile/:tableId", gen.GenApiToFile)
-		r.GET("/gen/todb/:tableId", gen.GenMenuAndApi)
+		if GenWriteRoutesEnabled() {
+			r.GET("/gen/toproject/:tableId", gen.GenCode)
+			r.GET("/gen/apitofile/:tableId", gen.GenApiToFile)
+			r.GET("/gen/todb/:tableId", gen.GenMenuAndApi)
+		}
 		sysTable := tools.SysTable{}
 		r.GET("/gen/tabletree", sysTable.GetSysTablesTree)
 	}

--- a/app/other/router/gen_router_test.go
+++ b/app/other/router/gen_router_test.go
@@ -82,9 +82,9 @@ func TestGenWriteRoutesEnabledAgreesWithWhatWasRegistered(t *testing.T) {
 		t.Run("mode="+mode, func(t *testing.T) {
 			routes := registeredRoutes(t, mode)
 
-			// registeredRoutes puts the mode back before it returns, so it
-			// has to be set again to ask the predicate about the same mode
-			// the engine was built under.
+			// registeredRoutes puts the mode back before it returns, so ask
+			// the predicate under a mode set here - about the same value the
+			// engine was just built under.
 			previous := config.ApplicationConfig.Mode
 			t.Cleanup(func() { config.ApplicationConfig.Mode = previous })
 			config.ApplicationConfig.Mode = mode
@@ -96,5 +96,27 @@ func TestGenWriteRoutesEnabledAgreesWithWhatWasRegistered(t *testing.T) {
 					mode, claimed, actual)
 			}
 		})
+	}
+}
+
+// The helper restores the mode before it returns, so nothing it was asked
+// about leaks into what the caller does next.
+//
+// Worth a test of its own because the failure is silent: a helper that left
+// the mode set would make every assertion after the call read a value the
+// caller did not choose, and each of those assertions would still pass for as
+// long as the leaked value happened to be the right one.
+func TestRegisteredRoutesRestoresTheModeBeforeReturning(t *testing.T) {
+	const sentinel = "not-a-mode"
+
+	previous := config.ApplicationConfig.Mode
+	t.Cleanup(func() { config.ApplicationConfig.Mode = previous })
+	config.ApplicationConfig.Mode = sentinel
+
+	registeredRoutes(t, "prod")
+
+	if got := config.ApplicationConfig.Mode; got != sentinel {
+		t.Errorf("mode after the helper returned = %q, want %q - it was left set to what "+
+			"the helper was asked about", got, sentinel)
 	}
 }

--- a/app/other/router/gen_router_test.go
+++ b/app/other/router/gen_router_test.go
@@ -1,0 +1,100 @@
+package router
+
+import (
+	"testing"
+
+	"github.com/go-admin-team/go-admin-core/v2/sdk/config"
+)
+
+// genWritingRoutes are the three that do not read. They write Go and Vue
+// source onto the host, a migration, and rows in sys_menu.
+var genWritingRoutes = []string{
+	"/api/v1/gen/toproject/:tableId",
+	"/api/v1/gen/apitofile/:tableId",
+	"/api/v1/gen/todb/:tableId",
+}
+
+// genReadingRoutes are the rest of the generator's surface. Gating the three
+// above must not cost any of these: a deployment that cannot list its tables
+// or preview a template has lost the feature, not secured it.
+var genReadingRoutes = []string{
+	"/api/v1/gen/preview/:tableId",
+	"/api/v1/gen/tabletree",
+	"/api/v1/db/tables/page",
+	"/api/v1/db/columns/page",
+}
+
+// The endpoints that write are registered where the mode says development and
+// nowhere else.
+//
+// They are in CasbinExclude, so Enforce never runs for them and any account
+// that can log in may call them. dev is the shipped default and is where the
+// generator is meant to be used; demo keeps them because DemoEvn refuses these
+// three by name and saying so is the thing the demo is for. Everything else,
+// including the empty mode a process gets when nothing set one, is refused by
+// not existing.
+func TestGeneratorWritingRoutesExistOnlyWhereTheModeAllowsIt(t *testing.T) {
+	for _, tc := range []struct {
+		mode     string
+		expected bool
+		why      string
+	}{
+		{"dev", true, "the shipped default, and where the generator is used"},
+		{"demo", true, "registered so demo mode can refuse them by name"},
+		{"test", false, "a deployment, however much it is called a test"},
+		{"prod", false, "a deployment"},
+		{"", false, "no mode configured is not a reason to trust the caller"},
+	} {
+		t.Run("mode="+tc.mode, func(t *testing.T) {
+			routes := registeredRoutes(t, tc.mode)
+			for _, writing := range genWritingRoutes {
+				if got := routes[writing]; got != tc.expected {
+					t.Errorf("mode %q: %s registered = %v, want %v (%s)",
+						tc.mode, writing, got, tc.expected, tc.why)
+				}
+			}
+		})
+	}
+}
+
+// The other direction. Refusing too much is as much of a defect as refusing
+// too little, and the read-only half of the generator is what a demo shows.
+func TestGeneratorReadingRoutesExistInEveryMode(t *testing.T) {
+	for _, mode := range []string{"dev", "demo", "test", "prod", ""} {
+		t.Run("mode="+mode, func(t *testing.T) {
+			routes := registeredRoutes(t, mode)
+			for _, reading := range genReadingRoutes {
+				if !routes[reading] {
+					t.Errorf("mode %q: %s is not registered - the gate took a route that only reads",
+						mode, reading)
+				}
+			}
+		})
+	}
+}
+
+// GenWriteRoutesEnabled is what cmd/api reads to decide whether to warn at
+// start-up. If it and the registration ever disagree, the log says one thing
+// and the engine does another, so they are checked against each other rather
+// than each against a list.
+func TestGenWriteRoutesEnabledAgreesWithWhatWasRegistered(t *testing.T) {
+	for _, mode := range []string{"dev", "demo", "test", "prod", ""} {
+		t.Run("mode="+mode, func(t *testing.T) {
+			routes := registeredRoutes(t, mode)
+
+			// registeredRoutes puts the mode back before it returns, so it
+			// has to be set again to ask the predicate about the same mode
+			// the engine was built under.
+			previous := config.ApplicationConfig.Mode
+			t.Cleanup(func() { config.ApplicationConfig.Mode = previous })
+			config.ApplicationConfig.Mode = mode
+
+			claimed := GenWriteRoutesEnabled()
+			actual := routes["/api/v1/gen/todb/:tableId"]
+			if claimed != actual {
+				t.Errorf("mode %q: GenWriteRoutesEnabled() = %v but the route was registered = %v",
+					mode, claimed, actual)
+			}
+		})
+	}
+}

--- a/app/other/router/gen_router_test.go
+++ b/app/other/router/gen_router_test.go
@@ -120,3 +120,32 @@ func TestRegisteredRoutesRestoresTheModeBeforeReturning(t *testing.T) {
 			"the helper was asked about", got, sentinel)
 	}
 }
+
+// Changing the mode after the routes were built unregisters nothing.
+//
+// buildRouter has one call site, in run(), and route registration is not on
+// any phase or reload callback - so a configuration reload moves
+// config.ApplicationConfig.Mode without moving the routes. From that moment
+// GenWriteRoutesEnabled answers about a mode the engine was not built under.
+//
+// That gap is why the start-up warning tells the reader to restart rather than
+// only to change the mode. This pins it: if registration ever becomes dynamic,
+// this test fails and the message it justifies has to be revisited.
+func TestChangingTheModeDoesNotUnregisterWhatWasAlreadyBuilt(t *testing.T) {
+	built := registeredRoutes(t, "dev")
+	if !built["/api/v1/gen/todb/:tableId"] {
+		t.Fatal("built under dev without the writing routes, so this test asserts nothing")
+	}
+
+	previous := config.ApplicationConfig.Mode
+	t.Cleanup(func() { config.ApplicationConfig.Mode = previous })
+	config.ApplicationConfig.Mode = "prod"
+
+	if GenWriteRoutesEnabled() {
+		t.Fatal("the predicate still allows prod, so the disagreement below is not the one meant")
+	}
+	if !built["/api/v1/gen/todb/:tableId"] {
+		t.Error("the route left the engine when the mode changed - registration has become " +
+			"dynamic, and the start-up warning's advice to restart is now wrong")
+	}
+}

--- a/cmd/api/gen_warning_test.go
+++ b/cmd/api/gen_warning_test.go
@@ -1,0 +1,38 @@
+package api
+
+import (
+	"testing"
+
+	"github.com/go-admin-team/go-admin-core/v2/sdk/config"
+)
+
+// The warning fires exactly where the generator's writing endpoints are served
+// and nothing else refuses them.
+//
+// dev is the case the warning exists for: it is the shipped default, so it is
+// the mode a deployment that changed nothing is running in. demo serves the
+// routes too, but DemoEvn refuses all three by name, so warning there would
+// describe an exposure that is not there.
+func TestGeneratorWriteRoutesWarningFiresWhereTheExposureIs(t *testing.T) {
+	for _, tc := range []struct {
+		mode string
+		want bool
+		why  string
+	}{
+		{"dev", true, "shipped default, endpoints served and not refused"},
+		{"demo", false, "served, but DemoEvn refuses all three"},
+		{"test", false, "not served"},
+		{"prod", false, "not served"},
+		{"", false, "not served"},
+	} {
+		t.Run("mode="+tc.mode, func(t *testing.T) {
+			previous := config.ApplicationConfig.Mode
+			t.Cleanup(func() { config.ApplicationConfig.Mode = previous })
+			config.ApplicationConfig.Mode = tc.mode
+
+			if got := generatorWriteRoutesNeedWarning(); got != tc.want {
+				t.Errorf("mode %q: warning = %v, want %v (%s)", tc.mode, got, tc.want, tc.why)
+			}
+		})
+	}
+}

--- a/cmd/api/server.go
+++ b/cmd/api/server.go
@@ -374,7 +374,9 @@ func reportGeneratorWriteRoutes() {
 	log.Warnf("the code generator's writing endpoints are served in mode %q: "+
 		"/api/v1/gen/{toproject,apitofile,todb} write Go and Vue source onto this host and rows "+
 		"into this database, and they are in CasbinExclude, so any account that can log in may "+
-		"call them. Set application.mode to prod or test on anything that is not a workstation.",
+		"call them. Set application.mode to prod or test on anything that is not a workstation, "+
+		"then restart: these routes were registered at start-up and a configuration reload does "+
+		"not rebuild them.",
 		config.ApplicationConfig.Mode)
 }
 

--- a/cmd/api/server.go
+++ b/cmd/api/server.go
@@ -177,6 +177,7 @@ func run() error {
 		gin.SetMode(gin.ReleaseMode)
 	}
 	buildRouter()
+	reportGeneratorWriteRoutes()
 
 	srv := &http.Server{
 		Addr:         fmt.Sprintf("%s:%d", config.ApplicationConfig.Host, config.ApplicationConfig.Port),
@@ -355,6 +356,37 @@ const (
 	dockerStopGraceSeconds = 10
 	kubernetesGraceSeconds = 30
 )
+
+// reportGeneratorWriteRoutes says whether this process serves the code
+// generator's writing endpoints, and to whom.
+//
+// The endpoints are gated on the mode, and the shipped configuration says dev -
+// so the deployment most likely to be exposed is the one that changed nothing,
+// and the one least likely to go looking. Silence there would leave the gate
+// technically correct and practically useless.
+//
+// Nothing is said in demo mode. The routes are registered, but DemoEvn refuses
+// all three by name, so a warning would describe an exposure that is not there.
+func reportGeneratorWriteRoutes() {
+	if !generatorWriteRoutesNeedWarning() {
+		return
+	}
+	log.Warnf("the code generator's writing endpoints are served in mode %q: "+
+		"/api/v1/gen/{toproject,apitofile,todb} write Go and Vue source onto this host and rows "+
+		"into this database, and they are in CasbinExclude, so any account that can log in may "+
+		"call them. Set application.mode to prod or test on anything that is not a workstation.",
+		config.ApplicationConfig.Mode)
+}
+
+// generatorWriteRoutesNeedWarning reports whether there is an exposure to warn
+// about: the endpoints are served, and nothing else is refusing them.
+//
+// Split from the logging so the decision can be tested. A warning nobody can
+// make fire is indistinguishable from no warning at all, and this one exists
+// precisely for the case nobody is looking at.
+func generatorWriteRoutesNeedWarning() bool {
+	return otherrouter.GenWriteRoutesEnabled() && config.ApplicationConfig.Mode != "demo"
+}
 
 // reportShutdownBudget states what a shutdown will spend and whether it fits.
 //


### PR DESCRIPTION
Closes #914.

## The exposure

Three of the code generator's endpoints do not read:

| Endpoint | What it writes |
| --- | --- |
| `GET /api/v1/gen/toproject/:tableId` | seven Go and Vue source files onto the host, one under the path `gen.frontpath` names |
| `GET /api/v1/gen/apitofile/:tableId` | a migration under `cmd/migrate/migration/version-local/` |
| `GET /api/v1/gen/todb/:tableId` | rows in `sys_menu` |

All three are GET, and all three are listed in `CasbinExclude`, which `AuthCheckRole` skips — so `Enforce` never runs for them. Any account that can log in could call them, on every deployment.

## What this does

They are registered only where `application.mode` is `dev` or `demo`.

| mode | registered | why |
| --- | --- | --- |
| `dev` | yes | the shipped default, and where the generator is meant to be used |
| `demo` | yes | `DemoEvn` refuses all three by name and explains itself — that answer is better than a 404, and it is what the demo is for |
| `test` | no | a deployment, however it is labelled |
| `prod` | no | a deployment |
| unset | no | no mode configured is not a reason to trust the caller |

The read-only half of the generator — `/gen/preview`, `/gen/tabletree`, `/db/tables/page`, `/db/columns/page` — is registered in every mode. Refusing too much would be as much of a defect as refusing too little.

`CasbinExclude` is left alone deliberately. Taking the three off that list would make them require a permission no existing deployment has granted, so every non-admin user would start getting 403 from a tool that worked yesterday. That is a migration, not a guard.

## The gap this leaves, and the second commit

The gate is decided by the mode, and the shipped `config/settings.yml` says `mode: dev`. So a deployment that configured a database and nothing else is still serving these endpoints — and it is the one least likely to go looking. Start-up now says so:

```
the code generator's writing endpoints are served in mode "dev": /api/v1/gen/{toproject,apitofile,todb}
write Go and Vue source onto this host and rows into this database, and they are in CasbinExclude,
so any account that can log in may call them. Set application.mode to prod or test on anything that
is not a workstation.
```

Nothing is said in `demo` mode, where the routes exist but `DemoEvn` refuses them.

## Checks

25 packages pass, `go run ./tools/checksilent` reports 0 errors and 0 warnings, and `gofmt` is clean on every changed file.

Seven counter-proofs, each red on the test that names the behaviour and green elsewhere:

| Degradation | Red on |
| --- | --- |
| gate always allows | writing routes: `test`, `prod`, unset |
| gate always refuses | writing routes: `dev`, `demo` — and `TestEveryRouteDemoModeRefusesStillExists` |
| a read-only route moved inside the gate | reading routes: `test`, `prod`, unset |
| condition spelled at the registration site instead of calling the predicate | the agreement test: `test`, unset |
| warning fires in demo too | warning: `demo` |
| warning never fires | warning: `dev` |
| warning always fires | warning: every mode but `dev` |

The second and sixth are the ones worth naming. The second is what keeps this from quietly costing the demo the feature it exists to show. The sixth is what shows the warning can fire at all — a `Warnf` nobody can make reach is the same as no warning.

## Not in this change

The generator's menu is still in the sidebar under `test` and `prod`, so the page is reachable and its buttons now answer 404. Hiding it belongs in go-admin-ui.
