### PR TITLE
fix🐛: report job stop timeouts as errors

### DIFF
--- a/app/jobs/jobbase.go
+++ b/app/jobs/jobbase.go
@@ -209,7 +209,7 @@ func (e *ExecJob) addJob(c *cron.Cron) (int, error) {
 
 // Remove 移除任务
 func Remove(c *cron.Cron, entryID int) chan bool {
-	ch := make(chan bool)
+	ch := make(chan bool, 1)
 	go func() {
 		c.Remove(cron.EntryID(entryID))
 		fmt.Println(time.Now().Format(timeFormat), " [INFO] JobCore Remove success ,info entryID :", entryID)

--- a/app/jobs/service/sys_job.go
+++ b/app/jobs/service/sys_job.go
@@ -39,7 +39,7 @@ func (e *SysJob) RemoveJob(c *dto.GeneralDelDto) error {
 		}
 	case <-time.After(time.Second * 1):
 		e.Msg = "操作超时！"
-		return nil
+		return errors.New(e.Msg)
 	}
 	return nil
 }

--- a/app/jobs/service/sys_job_test.go
+++ b/app/jobs/service/sys_job_test.go
@@ -1,0 +1,88 @@
+package service
+
+import (
+	"testing"
+	"time"
+
+	"github.com/glebarez/sqlite"
+	coreservice "github.com/go-admin-team/go-admin-core/v2/sdk/service"
+	"github.com/robfig/cron/v3"
+	"gorm.io/gorm"
+
+	"go-admin/app/jobs/models"
+	"go-admin/common/dto"
+)
+
+type blockedSchedule struct {
+	started chan struct{}
+	release chan struct{}
+}
+
+func (s blockedSchedule) Next(now time.Time) time.Time {
+	close(s.started)
+	<-s.release
+	return now.Add(time.Hour)
+}
+
+func TestRemoveJob(t *testing.T) {
+	for _, blocked := range []bool{false, true} {
+		name := "success"
+		if blocked {
+			name = "timeout"
+		}
+		t.Run(name, func(t *testing.T) {
+			db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+			if err != nil {
+				t.Fatal(err)
+			}
+			sqlDB, err := db.DB()
+			if err != nil {
+				t.Fatal(err)
+			}
+			t.Cleanup(func() { _ = sqlDB.Close() })
+			if err := db.AutoMigrate(&models.SysJob{}); err != nil {
+				t.Fatal(err)
+			}
+
+			c := cron.New()
+			schedule := blockedSchedule{make(chan struct{}), make(chan struct{})}
+			entryID := c.Schedule(schedule, cron.FuncJob(func() {}))
+			if blocked {
+				c.Start()
+				t.Cleanup(func() {
+					close(schedule.release)
+					<-c.Stop().Done()
+				})
+				select {
+				case <-schedule.started:
+				case <-time.After(5 * time.Second):
+					t.Fatal("scheduler did not start")
+				}
+			}
+			job := models.SysJob{EntryId: int(entryID)}
+			if err := db.Create(&job).Error; err != nil {
+				t.Fatal(err)
+			}
+			s := SysJob{Service: coreservice.Service{Orm: db}, Cron: c}
+			err = s.RemoveJob(&dto.GeneralDelDto{Id: job.JobId})
+			if blocked {
+				if err == nil || err.Error() != "操作超时！" {
+					t.Errorf("RemoveJob error = %v, want timeout error", err)
+				}
+			} else if err != nil {
+				t.Fatal(err)
+			}
+			var saved models.SysJob
+			if err := db.First(&saved, job.JobId).Error; err != nil {
+				t.Fatal(err)
+			}
+			wantEntryID := 0
+			if blocked {
+				wantEntryID = int(entryID)
+			}
+			if saved.EntryId != wantEntryID {
+				t.Errorf("entry_id = %d, want %d", saved.EntryId, wantEntryID)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes #890.

When stopping a scheduled job takes longer than the one-second limit, `RemoveJob` now returns the timeout error to `RemoveJobForService`. The API can therefore use its existing error response instead of reporting success. The database entry ID remains unchanged until removal is acknowledged.

The one-shot removal result channel is buffered so that a late completion can exit after the caller has timed out.

Validation:
- Regression test using an in-memory SQLite database and a real cron scheduler: a deliberately blocked scheduler reproduced the original nil error, and now returns the timeout error without clearing `entry_id`.
- The successful removal case clears `entry_id` as before.
- `make test` (`go test -race -cover ./...`), `make checksilent`, `go vet ./...`, and `go build` pass.

Implemented and locally validated with OpenAI Codex.
