### PR TITLE
Stop the demo host filling up with old images

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -117,7 +117,41 @@ jobs:
 
             test -f "$CFG" || { echo "宿主机配置缺失，中止部署"; exit 1; }
 
+            # Old images of this repository are removed here and nowhere else.
+            # Every deployment pulls one tagged with its commit and nothing ever
+            # removed the previous one, so they only accumulated: 68 of them
+            # filled the disk and the next deployment could not pull.
+            #
+            # Three are kept so a release can be re-run by tag by hand.
+            #
+            # Only this repository's images are listed, because the host runs
+            # other services whose images are not this script's business. The
+            # image the live container is on is excluded by id rather than by
+            # position, so it survives even if the listing order is not what
+            # it looks like. With no container to ask, the function returns
+            # rather than running the pipeline on an empty id - which would
+            # also delete nothing, but by way of grep -v matching every line,
+            # which reads like the opposite of what it does. No -f, so an image
+            # any container still holds - including the one kept for rollback -
+            # is refused rather than taken away from it.
+            prune_old_images() {
+              REPO="${IMG%:*}"
+              LIVE=$(sudo docker inspect -f '{{.Image}}' "$NAME" 2>/dev/null | sed 's/^sha256://' | cut -c1-12)
+              [ -n "$LIVE" ] || return 0
+              sudo docker images "$REPO" --format '{{.ID}} {{.Repository}}:{{.Tag}}' \
+                | grep -v "^$LIVE" \
+                | tail -n +3 \
+                | awk '{print $2}' \
+                | xargs -r -n1 sudo docker rmi >/dev/null 2>&1 || true
+            }
+
             sudo docker login --username=${{ secrets.DOCKER_USERNAME }} registry.ap-northeast-1.aliyuncs.com --password=${{ secrets.DOCKER_PASSWORD }}
+            # Before the pull, not only after a successful deploy. The pull
+            # is the first thing here that needs space and it is where a full
+            # disk stops this script, so a cleanup that only runs afterwards
+            # never runs on the host that needs it: rerunning the workflow
+            # fails at the same pull, and the disk has to be cleared by hand.
+            prune_old_images
             sudo docker pull "$IMG" || { echo "拉取镜像失败，中止部署"; exit 1; }
 
             # 迁移用新镜像跑。失败时线上仍是旧版本配旧 schema，是自洽的；
@@ -156,30 +190,9 @@ jobs:
             if [ "$ok" = "1" ]; then
               sudo docker rm -f "$PREV" >/dev/null 2>&1 || true
 
-              # Old images of this repository are deleted here and nowhere
-              # else. Every deployment pulls one image tagged with its commit
-              # and nothing ever removed the previous one, so they only ever
-              # accumulated: 68 of them filled the disk and the next deployment
-              # could not pull. That one stopped at the pull, which
-              # is the harmless place to stop - the site kept serving the image
-              # it already had - but no later run would have recovered either.
-              #
-              # Three are kept so a release can be re-run by tag by hand.
-              #
-              # Only this repository's images are listed: the host runs other
-              # services whose images are not this script's business. The image
-              # the new container is on is excluded by id rather than by
-              # position, so it survives even if the listing order is not what
-              # it looks like. No -f, so an image some container still holds is
-              # refused rather than taken away from it, and a refusal does not
-              # fail a deployment that has already succeeded.
-              REPO="${IMG%:*}"
-              LIVE=$(sudo docker inspect -f '{{.Image}}' "$NAME" | sed 's/^sha256://' | cut -c1-12)
-              sudo docker images "$REPO" --format '{{.ID}} {{.Repository}}:{{.Tag}}' \
-                | grep -v "^$LIVE" \
-                | tail -n +3 \
-                | awk '{print $2}' \
-                | xargs -r -n1 sudo docker rmi >/dev/null 2>&1 || true
+              # Again, so the image this deployment replaced falls out of the
+              # window rather than waiting for the next deployment to notice.
+              prune_old_images
             else
               echo "健康检查失败，回滚到上一版本"
               sudo docker logs --tail 40 "$NAME" 2>&1 || true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -155,6 +155,31 @@ jobs:
 
             if [ "$ok" = "1" ]; then
               sudo docker rm -f "$PREV" >/dev/null 2>&1 || true
+
+              # Old images of this repository are deleted here and nowhere
+              # else. Every deployment pulls one image tagged with its commit
+              # and nothing ever removed the previous one, so they only ever
+              # accumulated: 68 of them filled the disk and the next deployment
+              # could not pull. That one stopped at the pull, which
+              # is the harmless place to stop - the site kept serving the image
+              # it already had - but no later run would have recovered either.
+              #
+              # Three are kept so a release can be re-run by tag by hand.
+              #
+              # Only this repository's images are listed: the host runs other
+              # services whose images are not this script's business. The image
+              # the new container is on is excluded by id rather than by
+              # position, so it survives even if the listing order is not what
+              # it looks like. No -f, so an image some container still holds is
+              # refused rather than taken away from it, and a refusal does not
+              # fail a deployment that has already succeeded.
+              REPO="${IMG%:*}"
+              LIVE=$(sudo docker inspect -f '{{.Image}}' "$NAME" | sed 's/^sha256://' | cut -c1-12)
+              sudo docker images "$REPO" --format '{{.ID}} {{.Repository}}:{{.Tag}}' \
+                | grep -v "^$LIVE" \
+                | tail -n +3 \
+                | awk '{print $2}' \
+                | xargs -r -n1 sudo docker rmi >/dev/null 2>&1 || true
             else
               echo "健康检查失败，回滚到上一版本"
               sudo docker logs --tail 40 "$NAME" 2>&1 || true

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,10 +4,26 @@ FROM alpine
 
 RUN sed -i 's/dl-cdn.alpinelinux.org/mirrors.ustc.edu.cn/g' /etc/apk/repositories
 
-RUN apk update --no-cache
-RUN apk add --update gcc g++ libc6-compat
-RUN apk add --no-cache ca-certificates
-RUN apk add --no-cache tzdata
+# Runtime packages only.
+#
+# gcc and g++ used to be installed here and were 273MB of a 381MB image. The
+# binary this image runs is compiled and linked before the image is built and
+# arrives as a COPY, so nothing in the container ever invokes a compiler -
+# there is no toolchain to drive it with either, since Go itself is not
+# installed.
+#
+# That layer was also why a host could not share storage between images. apk
+# resolves against an index that moves, so the layer digest differed on every
+# build and no two images shared it: a host keeping one image per deployed
+# commit stored a private 273MB copy each time. 68 of them filled the disk
+# and the next deployment could not pull.
+#
+# libc6-compat stays. Nothing measured needs it - the binary CI produces is
+# statically linked, and a container built without libc6-compat resolves a
+# hostname and opens a database connection exactly as one built with it - but
+# it is half a megabyte and it covers a ./main that was linked dynamically,
+# which this Dockerfile has no way to check.
+RUN apk add --no-cache ca-certificates tzdata libc6-compat
 ENV TZ Asia/Shanghai
 
 COPY ./main /main


### PR DESCRIPTION
A deployment failed on `docker pull` with `no space left on device`. The host
was full: 68 images of this repository had accumulated, one per deployed commit,
and nothing had ever removed one.

That is the harmless place for a deployment to fail. The pull happens before the
container is touched, so the site kept serving the image it already had. But
nothing would have recovered on its own, and every later deployment would have
failed the same way.

Two things put the host there, and this changes both.

## The runtime image carries a compiler

`gcc` and `g++` were 273MB of a 381MB image. Nothing in the container invokes
them: the binary is compiled and statically linked before the image is built and
arrives as a `COPY`, and Go is not installed in the image either.

The layer cost more than its size. `apk` resolves against an index that moves,
so the layer's digest differed on every build and no two images shared it. A
host keeping one image per deployed commit stored a private copy of all 273MB
each time, instead of storing it once.

`libc6-compat` is kept. Nothing measured needs it - a container built without it
resolves a hostname and opens a database connection exactly as one built with it
- but it costs half a megabyte and it covers a `./main` that was linked
dynamically, which the Dockerfile has no way to check.

## The deploy never removed an image

The deploy script removes the previous *container* once the new one is healthy,
and leaves the image behind. It now also removes this repository's older images,
keeping three so a release can still be re-run by tag by hand.

Only this repository's images are listed, because the host runs other services.
The image the new container is on is excluded by id rather than by position, and
`rmi` is called without `-f`, so an image some container still holds is refused
rather than taken away from it.

## Verification

The Dockerfile in this branch was built and run under the same check the deploy
script uses - `/api/v1/captcha` answering 200 and the log reporting the datastore
connected:

| build | check | apk layer |
|---|---|---|
| current recipe (control) | pass | 273MB |
| this branch | pass | absent |
| this branch, binary deliberately truncated | **fail**, `exit=139` | absent |

The third row is why the first two mean anything: the check distinguishes a
serving process from a dead one rather than passing on anything that starts.

A fourth build dropped `libc6-compat` as well and also passed, including
resolving a hostname and reaching a database - which is why the comment in the
Dockerfile says it is kept as cover rather than because something needs it.

The cleanup pipeline was run against a real docker daemon with five images newer
than the running one, so position alone no longer protected it. The pipeline left
three and did not select the live one. Removing the id exclusion from the same
pipeline did select it, so that guard is load-bearing rather than decorative.
